### PR TITLE
parameterise Renderer in Cause.pretty

### DIFF
--- a/packages/system/src/Cause/pretty.ts
+++ b/packages/system/src/Cause/pretty.ts
@@ -288,7 +288,7 @@ export function prettyM<E1>(cause: Cause<E1>, renderer: Renderer<E1>) {
 const defaultErrorToLines = (error: unknown) =>
   error instanceof Error ? renderError(error) : lines(renderToString(error))
 
-const defaultRenderer: Renderer = {
+export const defaultRenderer: Renderer = {
   renderError: defaultErrorToLines,
   renderTrace: prettyTrace,
   renderUnknown: defaultErrorToLines

--- a/packages/system/src/Effect/runtime.ts
+++ b/packages/system/src/Effect/runtime.ts
@@ -4,7 +4,7 @@ import { isTracingEnabled } from "@effect-ts/tracing-utils"
 
 import * as Cause from "../Cause/core"
 import type { Renderer } from "../Cause/pretty"
-import { pretty } from "../Cause/pretty"
+import { defaultRenderer, pretty } from "../Cause/pretty"
 // exit
 import { HasClock, LiveClock } from "../Clock"
 import type { Exit } from "../Exit/exit"
@@ -15,7 +15,6 @@ import { interruptible } from "../Fiber/core"
 import { newFiberId } from "../Fiber/id"
 import { Platform } from "../Fiber/platform"
 import type { Callback } from "../Fiber/state"
-import { prettyTrace } from "../Fiber/tracing"
 import { constVoid, identity } from "../Function"
 import { none } from "../Option"
 import { defaultRandom, HasRandom } from "../Random"
@@ -48,7 +47,7 @@ export function defaultEnv(): DefaultEnv {
 export type AsyncCancel<E, A> = UIO<Exit<E, A>>
 
 export const prettyReporter: FailureReporter = (e) => {
-  console.error(pretty(e, prettyTrace))
+  console.error(pretty(e, defaultRenderer))
 }
 
 const defaultPlatform = new Platform(
@@ -61,7 +60,7 @@ const defaultPlatform = new Platform(
   25,
   25,
   25,
-  prettyTrace,
+  defaultRenderer,
   constVoid,
   10_000
 )


### PR DESCRIPTION
Lets client code control how `Cause`s are printed.