### PR TITLE
Restore sync ergonomics

### DIFF
--- a/packages/system/src/Effect/interop.ts
+++ b/packages/system/src/Effect/interop.ts
@@ -1,11 +1,9 @@
 import * as Async from "../Async"
 import * as IO from "../IO"
-import * as Sync from "../Sync"
 import { accessM, effectTotal, succeed } from "./core"
 import type { Effect } from "./effect"
 import { effectAsyncInterrupt } from "./effectAsyncInterrupt"
 import { fail } from "./fail"
-import { fromEither } from "./fromEither"
 import { interrupt } from "./interruption"
 
 /**
@@ -42,11 +40,4 @@ export function fromAsync<R, E, A>(async: Async.Async<R, E, A>): Effect<R, E, A>
  */
 export function fromIO<A>(io: IO.IO<A>): Effect<unknown, never, A> {
   return effectTotal(() => IO.run(io))
-}
-
-/**
- * Lift Sync into Effect
- */
-export function fromSync<R, E, A>(sync: Sync.Sync<R, E, A>): Effect<R, E, A> {
-  return accessM((r: R) => fromEither(() => Sync.runEitherEnv(r)(sync)))
 }

--- a/packages/system/src/Effect/primitives.ts
+++ b/packages/system/src/Effect/primitives.ts
@@ -9,6 +9,7 @@ import type { FiberRef } from "../FiberRef/fiberRef"
 import type * as O from "../Option"
 import type { Scope } from "../Scope"
 import type { Supervisor } from "../Supervisor"
+import type { XPure } from "../XPure/core"
 import type { Effect } from "./effect"
 import { Base } from "./effect"
 
@@ -42,6 +43,7 @@ export type Instruction =
   | IOverrideForkScope<any, any, any>
   | ITracingStatus<any, any, any>
   | IPlatform<any, any, any>
+  | XPure<unknown, never, any, any, any>
 
 export class IFail<E> extends Base<unknown, E, never> {
   readonly _tag = "Fail"

--- a/packages/system/src/XPure/core.ts
+++ b/packages/system/src/XPure/core.ts
@@ -1,5 +1,7 @@
 /* eslint-disable prefer-const */
-import { _A, _E, _R, _U } from "../Effect/commons"
+import { _A, _E, _I, _R, _U } from "../Effect/commons"
+import type { EffectURI } from "../Effect/effect"
+import type { Instruction } from "../Effect/primitives"
 import * as E from "../Either/core"
 import { constant } from "../Function"
 import { Stack } from "../Stack"
@@ -12,13 +14,19 @@ import { Stack } from "../Stack"
  * including context, state, and failure.
  */
 export abstract class XPure<S1, S2, R, E, A> {
+  readonly _tag = "XPure"
+
   readonly _S1!: (_: S1) => void
   readonly _S2!: () => S2;
 
-  readonly [_U]!: "XPure";
+  readonly [_U]!: EffectURI;
   readonly [_E]!: () => E;
   readonly [_A]!: () => A;
   readonly [_R]!: (_: R) => void
+
+  get [_I](): Instruction {
+    return this as any
+  }
 }
 
 /**

--- a/packages/system/test/mix.test.ts
+++ b/packages/system/test/mix.test.ts
@@ -1,5 +1,6 @@
 import * as A from "../src/Async"
 import * as T from "../src/Effect"
+import * as Ex from "../src/Exit"
 import { pipe } from "../src/Function"
 import * as IO from "../src/IO"
 import * as S from "../src/Sync"
@@ -8,7 +9,7 @@ describe("Effect", () => {
   it("mix", async () => {
     expect(
       await pipe(
-        T.fromSync(S.accessM((n: number) => S.sync(() => n + 1))),
+        S.accessM((n: number) => S.sync(() => n + 1)),
         T.chain((n) => T.effectTotal(() => n + 1)),
         T.chain((n) => T.fromIO(IO.sync(() => n + 1))),
         T.chain((n) => T.fromAsync(A.sync(() => n + 1))),
@@ -16,5 +17,8 @@ describe("Effect", () => {
         T.runPromise
       )
     ).toEqual(5)
+  })
+  it("mix fail", async () => {
+    expect(await pipe(S.fail(0), T.runPromiseExit)).toEqual(Ex.fail(0))
   })
 })


### PR DESCRIPTION
This PR re-add direct interpretation of Sync in Effect, it does so by adding a primitive into effect rather than adding an interpreter in Sync so it will respect the tree-shakability contract of sync