### PR TITLE
Update from node cb

### DIFF
--- a/packages/system/src/Effect/fromNodeCb.ts
+++ b/packages/system/src/Effect/fromNodeCb.ts
@@ -50,6 +50,10 @@ export function fromNodeCb<A, B, C, D, E, L, R>(
   ) => void,
   __trace?: string
 ): (a: A, b: B, c: C, d: D, e: E) => IO<L, R>
+export function fromNodeCb<A extends any[], L, R>(
+  f: (this: unknown, ...args: [...A, (e: L | null | undefined, r?: R) => void]) => void,
+  __trace?: string
+): (...args: A) => IO<L, R>
 export function fromNodeCb<L, R>(f: Function, __trace?: string): () => IO<L, R> {
   return function () {
     // eslint-disable-next-line prefer-rest-params

--- a/packages/system/src/Effect/fromNodeCb.ts
+++ b/packages/system/src/Effect/fromNodeCb.ts
@@ -6,27 +6,41 @@ import { effectAsync } from "./effectAsync"
 import { fail } from "./fail"
 
 export function fromNodeCb<L, R>(
-  f: (cb: (e: L | null | undefined, r?: R) => void) => void,
+  f: (this: unknown, cb: (e: L | null | undefined, r?: R) => void) => void,
   __trace?: string
 ): () => IO<L, R>
 export function fromNodeCb<A, L, R>(
-  f: (a: A, cb: (e: L | null | undefined, r?: R) => void) => void,
+  f: (this: unknown, a: A, cb: (e: L | null | undefined, r?: R) => void) => void,
   __trace?: string
 ): (a: A) => IO<L, R>
 export function fromNodeCb<A, B, L, R>(
-  f: (a: A, b: B, cb: (e: L | null | undefined, r?: R) => void) => void,
+  f: (this: unknown, a: A, b: B, cb: (e: L | null | undefined, r?: R) => void) => void,
   __trace?: string
 ): (a: A, b: B) => IO<L, R>
 export function fromNodeCb<A, B, C, L, R>(
-  f: (a: A, b: B, c: C, cb: (e: L | null | undefined, r?: R) => void) => void,
+  f: (
+    this: unknown,
+    a: A,
+    b: B,
+    c: C,
+    cb: (e: L | null | undefined, r?: R) => void
+  ) => void,
   __trace?: string
 ): (a: A, b: B, c: C) => IO<L, R>
 export function fromNodeCb<A, B, C, D, L, R>(
-  f: (a: A, b: B, c: C, d: D, cb: (e: L | null | undefined, r?: R) => void) => void,
+  f: (
+    this: unknown,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    cb: (e: L | null | undefined, r?: R) => void
+  ) => void,
   __trace?: string
 ): (a: A, b: B, c: C, d: D) => IO<L, R>
 export function fromNodeCb<A, B, C, D, E, L, R>(
   f: (
+    this: unknown,
     a: A,
     b: B,
     c: C,


### PR DESCRIPTION
1. Added `this: unknown` which doesn't allow unbound methods to be passed in.
2. Added overload for other cases. I haven't removed explicit cases for 0-5 arguments, because I noticed in some situations explicit generics actually work better than the overload based on spreads.