### PR TITLE
Hide Hub implementation details

### DIFF
--- a/packages/system/src/Hub/_internal/BoundedHubArb.ts
+++ b/packages/system/src/Hub/_internal/BoundedHubArb.ts
@@ -17,14 +17,6 @@ export class BoundedHubArb<A> extends Hub<A> {
     this.array = Array.from({ length: requestedCapacity })
     this.subscribers = Array.from({ length: requestedCapacity })
     this.capacity = requestedCapacity
-
-    this.isEmpty = this.isEmpty.bind(this)
-    this.isFull = this.isFull.bind(this)
-    this.publish = this.publish.bind(this)
-    this.publishAll = this.publishAll.bind(this)
-    this.size = this.size.bind(this)
-    this.slide = this.slide.bind(this)
-    this.subscribe = this.subscribe.bind(this)
   }
 
   isEmpty(): boolean {

--- a/packages/system/src/Hub/_internal/BoundedHubPow2.ts
+++ b/packages/system/src/Hub/_internal/BoundedHubPow2.ts
@@ -19,14 +19,6 @@ export class BoundedHubPow2<A> extends Hub<A> {
     this.mask = requestedCapacity = 1
     this.subscribers = Array.from({ length: requestedCapacity })
     this.capacity = requestedCapacity
-
-    this.isEmpty = this.isEmpty.bind(this)
-    this.isFull = this.isFull.bind(this)
-    this.publish = this.publish.bind(this)
-    this.publishAll = this.publishAll.bind(this)
-    this.size = this.size.bind(this)
-    this.slide = this.slide.bind(this)
-    this.subscribe = this.subscribe.bind(this)
   }
 
   isEmpty(): boolean {

--- a/packages/system/src/Hub/_internal/BoundedHubSingle.ts
+++ b/packages/system/src/Hub/_internal/BoundedHubSingle.ts
@@ -11,13 +11,6 @@ export class BoundedHubSingle<A> extends Hub<A> {
 
   constructor() {
     super()
-    this.isEmpty = this.isEmpty.bind(this)
-    this.isFull = this.isFull.bind(this)
-    this.publish = this.publish.bind(this)
-    this.publishAll = this.publishAll.bind(this)
-    this.size = this.size.bind(this)
-    this.slide = this.slide.bind(this)
-    this.subscribe = this.subscribe.bind(this)
   }
 
   isEmpty(): boolean {

--- a/packages/system/src/Hub/_internal/UnboundedHub.ts
+++ b/packages/system/src/Hub/_internal/UnboundedHub.ts
@@ -22,14 +22,6 @@ export class UnboundedHub<A> extends Hub<A> {
     super()
 
     this.publisherTail = this.publisherHead
-
-    this.isEmpty = this.isEmpty.bind(this)
-    this.isFull = this.isFull.bind(this)
-    this.publish = this.publish.bind(this)
-    this.publishAll = this.publishAll.bind(this)
-    this.size = this.size.bind(this)
-    this.slide = this.slide.bind(this)
-    this.subscribe = this.subscribe.bind(this)
   }
 
   isEmpty(): boolean {

--- a/packages/system/src/Stream/Stream/broadcastedQueues.ts
+++ b/packages/system/src/Stream/Stream/broadcastedQueues.ts
@@ -41,7 +41,7 @@ export function broadcastedQueues_<R, E, O>(
     M.do,
     M.bind("hub", () => T.toManaged(H.makeBounded<Take.Take<E, O>>(maximumLag))),
     M.bind("queues", ({ hub }) =>
-      M.collectAll(Array.from({ length: n }, () => hub.subscribe))
+      M.collectAll(Array.from({ length: n }, () => H.subscribe(hub)))
     ),
     M.tap(({ hub }) => M.fork(intoHubManaged_(self, hub))),
     M.map(({ queues }) => A.array(queues))

--- a/packages/system/src/Stream/Stream/broadcastedQueuesDynamic.ts
+++ b/packages/system/src/Stream/Stream/broadcastedQueuesDynamic.ts
@@ -1,5 +1,6 @@
 // tracing: off
 
+import * as H from "../../Hub"
 import type * as Q from "../../Queue"
 import * as M from "../_internal/managed"
 import type * as Take from "../Take"
@@ -19,7 +20,7 @@ export function broadcastedQueuesDynamic_<R, E, O>(
   self: Stream<R, E, O>,
   maximumLag: number
 ): M.Managed<R, never, M.Managed<unknown, never, Q.Dequeue<Take.Take<E, O>>>> {
-  return M.map_(toHub_(self, maximumLag), (_) => _.subscribe)
+  return M.map_(toHub_(self, maximumLag), (_) => H.subscribe(_))
 }
 
 /**

--- a/packages/system/src/Stream/Stream/fromChunkHub.ts
+++ b/packages/system/src/Stream/Stream/fromChunkHub.ts
@@ -1,5 +1,5 @@
 import type * as A from "../../Collections/Immutable/Chunk"
-import type * as H from "../../Hub"
+import * as H from "../../Hub"
 import { chain_ } from "./chain"
 import type { Stream } from "./definitions"
 import { fromChunkQueue } from "./fromChunkQueue"
@@ -11,5 +11,5 @@ import { managed } from "./managed"
 export function fromChunkHub<R, E, O>(
   hub: H.XHub<never, R, unknown, E, never, A.Chunk<O>>
 ): Stream<R, E, O> {
-  return chain_(managed(hub.subscribe), (queue) => fromChunkQueue(queue))
+  return chain_(managed(H.subscribe(hub)), (queue) => fromChunkQueue(queue))
 }

--- a/packages/system/src/Stream/Stream/fromChunkHubWithShutdown.ts
+++ b/packages/system/src/Stream/Stream/fromChunkHubWithShutdown.ts
@@ -1,5 +1,5 @@
 import type * as A from "../../Collections/Immutable/Chunk"
-import type * as H from "../../Hub"
+import * as H from "../../Hub"
 import type { Stream } from "./definitions"
 import { ensuringFirst_ } from "./ensuringFirst"
 import { fromChunkHub } from "./fromChunkHub"
@@ -10,5 +10,5 @@ import { fromChunkHub } from "./fromChunkHub"
 export function fromChunkHubWithShutdown<R, E, O>(
   hub: H.XHub<never, R, unknown, E, never, A.Chunk<O>>
 ): Stream<R, E, O> {
-  return ensuringFirst_(fromChunkHub(hub), hub.shutdown)
+  return ensuringFirst_(fromChunkHub(hub), H.shutdown(hub))
 }

--- a/packages/system/src/Stream/Stream/fromHub.ts
+++ b/packages/system/src/Stream/Stream/fromHub.ts
@@ -1,6 +1,6 @@
 // tracing: off
 
-import type * as H from "../../Hub"
+import * as H from "../../Hub"
 import { chain_ } from "./chain"
 import type { Stream } from "./definitions"
 import { fromQueue } from "./fromQueue"
@@ -12,5 +12,5 @@ import { managed } from "./managed"
 export function fromHub<R, E, A>(
   hub: H.XHub<never, R, unknown, E, never, A>
 ): Stream<R, E, A> {
-  return chain_(managed(hub.subscribe), (queue) => fromQueue(queue))
+  return chain_(managed(H.subscribe(hub)), (queue) => fromQueue(queue))
 }

--- a/packages/system/src/Stream/Stream/fromHubWithShutdown.ts
+++ b/packages/system/src/Stream/Stream/fromHubWithShutdown.ts
@@ -1,6 +1,6 @@
 // tracing: off
 
-import type * as H from "../../Hub"
+import * as H from "../../Hub"
 import type { Stream } from "./definitions"
 import { ensuringFirst_ } from "./ensuringFirst"
 import { fromHub } from "./fromHub"
@@ -11,5 +11,5 @@ import { fromHub } from "./fromHub"
 export function fromHubWithShutdown<R, E, A>(
   hub: H.XHub<never, R, unknown, E, never, A>
 ): Stream<R, E, A> {
-  return ensuringFirst_(fromHub(hub), hub.shutdown)
+  return ensuringFirst_(fromHub(hub), H.shutdown(hub))
 }

--- a/packages/system/src/Stream/Stream/toHub.ts
+++ b/packages/system/src/Stream/Stream/toHub.ts
@@ -18,7 +18,7 @@ export function toHub_<R, E, O>(
 ): M.Managed<R, never, H.XHub<never, unknown, unknown, never, never, Take.Take<E, O>>> {
   return pipe(
     H.makeBounded<Take.Take<E, O>>(capacity),
-    T.toManagedRelease((_) => _.shutdown),
+    T.toManagedRelease((_) => H.shutdown(_)),
     M.tap((hub) => M.fork(intoHubManaged_(self, hub)))
   )
 }


### PR DESCRIPTION
- Remove calls to .bind in constructors
- Hide Hub implementation details under HubInternal