### PR TITLE
Experimental Stream: Updated executor with latest changes

### DIFF
--- a/packages/system/src/Support/ImmutableQueue/index.ts
+++ b/packages/system/src/Support/ImmutableQueue/index.ts
@@ -42,4 +42,12 @@ export class ImmutableQueue<A> {
   filter(f: (a: A) => boolean) {
     return new ImmutableQueue(L.filter_(this.backing, f))
   }
+
+  static single<A>(a: A) {
+    return new ImmutableQueue(L.of(a))
+  }
+
+  [Symbol.iterator]() {
+    return L.toArray(this.backing).values()
+  }
 }


### PR DESCRIPTION
feat(support): Added 'single' and 'Symbol.iterator' to Support/ImmutableQueue

