### PR TITLE
chore: simplify tag api

### DIFF
--- a/packages/core/src/Sync/Layer/index.ts
+++ b/packages/core/src/Sync/Layer/index.ts
@@ -283,16 +283,16 @@ export function suspended<R, E, A>(layer: () => SyncLayer<R, E, A>) {
 
 export function fromSync<T extends AnyService>(tag: Tag<T>) {
   return <R, E>(_: Sy.Sync<R, E, T>): SyncLayer<R, E, Has<T>> =>
-    new Of(pipe(_, Sy.map(tag.of)))
+    new Of(pipe(_, Sy.map(tag.has)))
 }
 
 export function fromFunction<T extends AnyService>(tag: Tag<T>) {
   return <R>(_: (_: R) => T): SyncLayer<R, never, Has<T>> =>
-    new Of(pipe(Sy.access(_), Sy.map(tag.of)))
+    new Of(pipe(Sy.access(_), Sy.map(tag.has)))
 }
 
 export function fromValue<T extends AnyService>(tag: Tag<T>) {
-  return (_: T): SyncLayer<unknown, never, Has<T>> => new Of(Sy.succeed(tag.of(_)))
+  return (_: T): SyncLayer<unknown, never, Has<T>> => new Of(Sy.succeed(tag.has(_)))
 }
 
 export function and<R2, E2, A2>(left: SyncLayer<R2, E2, A2>) {

--- a/packages/system/src/Effect/asService.ts
+++ b/packages/system/src/Effect/asService.ts
@@ -18,8 +18,8 @@ export function asService<A extends AnyService>(has: Tag<A>, __trace?: string) {
  */
 export function asService_<R, E, A extends AnyService>(
   fa: Effect<R, E, A>,
-  has: Tag<A>,
+  tag: Tag<A>,
   __trace?: string
 ) {
-  return map_(fa, has.of, __trace)
+  return map_(fa, tag.has, __trace)
 }

--- a/packages/system/src/Effect/asService.ts
+++ b/packages/system/src/Effect/asService.ts
@@ -1,6 +1,6 @@
 // ets_tracing: off
 
-import type { AnyService, Tag } from "../Has"
+import type { AnyService, ServiceConstructor, Tag } from "../Has"
 import type { Effect } from "./effect"
 import { map_ } from "./map"
 
@@ -10,14 +10,14 @@ import { map_ } from "./map"
  * @datFirst asService_
  */
 export function asService<A extends AnyService>(has: Tag<A>, __trace?: string) {
-  return <R, E>(fa: Effect<R, E, A>) => asService_(fa, has, __trace)
+  return <R, E>(fa: Effect<R, E, ServiceConstructor<A>>) => asService_(fa, has, __trace)
 }
 
 /**
  * Maps the success value of this effect to a service.
  */
 export function asService_<R, E, A extends AnyService>(
-  fa: Effect<R, E, A>,
+  fa: Effect<R, E, ServiceConstructor<A>>,
   tag: Tag<A>,
   __trace?: string
 ) {

--- a/packages/system/src/Effect/has.ts
+++ b/packages/system/src/Effect/has.ts
@@ -8,7 +8,7 @@ import * as A from "../Collections/Immutable/Array"
 import * as R from "../Collections/Immutable/Dictionary"
 import * as core from "../Effect/core"
 import type { Effect } from "../Effect/effect"
-import type { AnyService, Has, Tag } from "../Has"
+import type { AnyService, Has, ServiceConstructor, Tag } from "../Has"
 import { mergeEnvironments } from "../Has"
 import { accessCallTrace } from "../Tracing"
 import type { UnionToIntersection } from "../Utils"
@@ -149,7 +149,7 @@ export function services<Ts extends readonly Tag<any>[]>(...s: Ts) {
  * Provides the service with the required Service Entry
  */
 export function provideServiceM<T extends AnyService>(_: Tag<T>) {
-  return <R, E>(service: Effect<R, E, T>, __trace?: string) =>
+  return <R, E>(service: Effect<R, E, ServiceConstructor<T>>, __trace?: string) =>
     <R1, E1, A1>(ma: Effect<R1 & Has<T>, E1, A1>): Effect<R & R1, E | E1, A1> =>
       core.accessM((r: R & R1) =>
         core.chain_(service, (t) =>
@@ -164,7 +164,7 @@ export function provideServiceM<T extends AnyService>(_: Tag<T>) {
 export function provideServiceM_<R1, E1, A1, R, E, T extends AnyService>(
   ma: Effect<R1 & Has<T>, E1, A1>,
   _: Tag<T>,
-  service: Effect<R, E, T>,
+  service: Effect<R, E, ServiceConstructor<T>>,
   __trace?: string
 ): Effect<R & R1, E | E1, A1> {
   return core.accessM((r: R & R1) =>
@@ -178,7 +178,7 @@ export function provideServiceM_<R1, E1, A1, R, E, T extends AnyService>(
  * Provides the service with the required Service Entry
  */
 export function provideService<T extends AnyService>(_: Tag<T>) {
-  return (service: T, __trace?: string) =>
+  return (service: ServiceConstructor<T>, __trace?: string) =>
     <R1, E1, A1>(ma: Effect<R1 & Has<T>, E1, A1>): Effect<R1, E1, A1> =>
       provideServiceM(_)(core.succeed(service), __trace)(ma)
 }
@@ -189,7 +189,7 @@ export function provideService<T extends AnyService>(_: Tag<T>) {
 export function provideService_<R1, E1, A1, T extends AnyService>(
   ma: Effect<R1 & Has<T>, E1, A1>,
   _: Tag<T>,
-  service: T,
+  service: ServiceConstructor<T>,
   __trace?: string
 ): Effect<R1, E1, A1> {
   return provideServiceM(_)(core.succeed(service), __trace)(ma)
@@ -200,7 +200,7 @@ export function provideService_<R1, E1, A1, T extends AnyService>(
  */
 export function replaceServiceM<R, E, T extends AnyService>(
   _: Tag<T>,
-  f: (_: T) => Effect<R, E, T>,
+  f: (_: T) => Effect<R, E, ServiceConstructor<T>>,
   __trace?: string
 ) {
   return <R1, E1, A1>(
@@ -215,7 +215,7 @@ export function replaceServiceM<R, E, T extends AnyService>(
 export function replaceServiceM_<R, E, T extends AnyService, R1, E1, A1>(
   ma: Effect<R1 & Has<T>, E1, A1>,
   _: Tag<T>,
-  f: (_: T) => Effect<R, E, T>,
+  f: (_: T) => Effect<R, E, ServiceConstructor<T>>,
   __trace?: string
 ): Effect<R & R1 & Has<T>, E | E1, A1> {
   return accessServiceM(_)((t) => provideServiceM(_)(f(t), __trace)(ma))
@@ -228,7 +228,7 @@ export function replaceServiceM_<R, E, T extends AnyService, R1, E1, A1>(
  */
 export function replaceService<T extends AnyService>(
   _: Tag<T>,
-  f: (_: T) => T,
+  f: (_: T) => ServiceConstructor<T>,
   __trace?: string
 ) {
   return <R1, E1, A1>(ma: Effect<R1 & Has<T>, E1, A1>): Effect<R1 & Has<T>, E1, A1> =>
@@ -241,7 +241,7 @@ export function replaceService<T extends AnyService>(
 export function replaceService_<R1, E1, A1, T extends AnyService>(
   ma: Effect<R1 & Has<T>, E1, A1>,
   _: Tag<T>,
-  f: (_: T) => T,
+  f: (_: T) => ServiceConstructor<T>,
   __trace?: string
 ): Effect<R1 & Has<T>, E1, A1> {
   return accessServiceM(_)((t) =>

--- a/packages/system/src/Effect/provideManaged.ts
+++ b/packages/system/src/Effect/provideManaged.ts
@@ -1,6 +1,6 @@
 // ets_tracing: off
 
-import type { AnyService, Has, Tag } from "../Has"
+import type { AnyService, Has, ServiceConstructor, Tag } from "../Has"
 import type { Managed } from "../Managed/managed"
 import { use_ } from "../Managed/use"
 import type { Effect } from "./effect"
@@ -19,7 +19,7 @@ export function provideSomeManaged<R, E, A>(managed: Managed<R, E, A>) {
  * Provides a managed to the given effect
  */
 export function provideServiceManaged<A extends AnyService>(tag: Tag<A>) {
-  return <R, E>(managed: Managed<R, E, A>) =>
+  return <R, E>(managed: Managed<R, E, ServiceConstructor<A>>) =>
     <R1, E1, A1>(self: Effect<R1 & Has<A>, E1, A1>): Effect<R & R1, E | E1, A1> =>
       use_(managed, (a) => has.provideService(tag)(a)(self))
 }

--- a/packages/system/src/Effect/toLayer.ts
+++ b/packages/system/src/Effect/toLayer.ts
@@ -1,6 +1,6 @@
 // ets_tracing: off
 
-import type { AnyService, Has, Tag } from "../Has"
+import type { AnyService, Has, ServiceConstructor, Tag } from "../Has"
 import * as L from "../Layer"
 import type { Effect } from "./effect"
 
@@ -15,6 +15,6 @@ export function toLayerRaw<R, E, A>(effect: Effect<R, E, A>): L.Layer<R, E, A> {
  * Constructs a layer from this effect.
  */
 export function toLayer<A extends AnyService>(tag: Tag<A>) {
-  return <R, E>(effect: Effect<R, E, A>): L.Layer<R, E, Has<A>> =>
+  return <R, E>(effect: Effect<R, E, ServiceConstructor<A>>): L.Layer<R, E, Has<A>> =>
     L.fromEffect(tag)(effect)
 }

--- a/packages/system/src/Effect/updateService.ts
+++ b/packages/system/src/Effect/updateService.ts
@@ -15,7 +15,7 @@ export function updateService_<T extends AnyService, R, E, A>(
 ): Effect<R & Has<T>, E, A> {
   return provideSome_(
     self,
-    (r: R & Has<T>) => ({ ...r, ...tag.of(f(tag.read(r))) }),
+    (r: R & Has<T>) => ({ ...r, ...tag.has(f(tag.read(r))) }),
     __trace
   )
 }

--- a/packages/system/src/Effect/updateService.ts
+++ b/packages/system/src/Effect/updateService.ts
@@ -1,6 +1,6 @@
 // ets_tracing: off
 
-import type { AnyService, Has, Tag } from "../Has"
+import type { AnyService, Has, ServiceConstructor, Tag } from "../Has"
 import type { Effect } from "./effect"
 import { provideSome_ } from "./provideSome"
 
@@ -10,7 +10,7 @@ import { provideSome_ } from "./provideSome"
 export function updateService_<T extends AnyService, R, E, A>(
   self: Effect<R, E, A>,
   tag: Tag<T>,
-  f: (_: T) => T,
+  f: (_: T) => ServiceConstructor<T>,
   __trace?: string
 ): Effect<R & Has<T>, E, A> {
   return provideSome_(
@@ -27,7 +27,7 @@ export function updateService_<T extends AnyService, R, E, A>(
  */
 export function updateService<T extends AnyService>(
   tag: Tag<T>,
-  f: (_: T) => T,
+  f: (_: T) => ServiceConstructor<T>,
   __trace?: string
 ): <R, E, A>(self: Effect<R, E, A>) => Effect<R & Has<T>, E, A> {
   return (self) => updateService_(self, tag, f, __trace)

--- a/packages/system/src/Managed/methods/api.ts
+++ b/packages/system/src/Managed/methods/api.ts
@@ -1773,7 +1773,7 @@ export function asService_<R, E, A extends AnyService>(
   self: Managed<R, E, A>,
   tag: Tag<A>
 ) {
-  return core.map_(self, tag.of)
+  return core.map_(self, tag.has)
 }
 
 /**

--- a/packages/system/src/Managed/methods/updateService.ts
+++ b/packages/system/src/Managed/methods/updateService.ts
@@ -1,6 +1,6 @@
 // ets_tracing: off
 
-import type { AnyService, Has, Tag } from "../../Has"
+import type { AnyService, Has, ServiceConstructor, Tag } from "../../Has"
 import { provideSome_ } from "../core"
 import type { Managed } from "../managed"
 
@@ -10,7 +10,7 @@ import type { Managed } from "../managed"
 export function updateService_<T extends AnyService, R, E, A>(
   self: Managed<R, E, A>,
   tag: Tag<T>,
-  f: (_: T) => T,
+  f: (_: T) => ServiceConstructor<T>,
   __trace?: string
 ): Managed<R & Has<T>, E, A> {
   return provideSome_(
@@ -27,7 +27,7 @@ export function updateService_<T extends AnyService, R, E, A>(
  */
 export function updateService<T extends AnyService>(
   tag: Tag<T>,
-  f: (_: T) => T,
+  f: (_: T) => ServiceConstructor<T>,
   __trace?: string
 ): <R, E, A>(self: Managed<R, E, A>) => Managed<R & Has<T>, E, A> {
   return (self) => updateService_(self, tag, f, __trace)

--- a/packages/system/src/Managed/methods/updateService.ts
+++ b/packages/system/src/Managed/methods/updateService.ts
@@ -15,7 +15,7 @@ export function updateService_<T extends AnyService, R, E, A>(
 ): Managed<R & Has<T>, E, A> {
   return provideSome_(
     self,
-    (r: R & Has<T>) => ({ ...r, ...tag.of(f(tag.read(r))) }),
+    (r: R & Has<T>) => ({ ...r, ...tag.has(f(tag.read(r))) }),
     __trace
   )
 }

--- a/packages/system/src/Sync/has.ts
+++ b/packages/system/src/Sync/has.ts
@@ -5,7 +5,7 @@
  */
 import * as A from "../Collections/Immutable/Array"
 import * as R from "../Collections/Immutable/Dictionary"
-import type { AnyService, Has, Tag } from "../Has"
+import type { AnyService, Has, ServiceConstructor, Tag } from "../Has"
 import { mergeEnvironments } from "../Has"
 import type { UnionToIntersection } from "../Utils"
 import * as X from "./core"
@@ -114,7 +114,7 @@ export function service<T extends AnyService>(s: Tag<T>) {
  * Provides the service with the required Service Entry
  */
 export function provideServiceM<T extends AnyService>(_: Tag<T>) {
-  return <R, E>(f: X.Sync<R, E, T>) =>
+  return <R, E>(f: X.Sync<R, E, ServiceConstructor<T>>) =>
     <R1, E1, A1>(ma: X.Sync<R1 & Has<T>, E1, A1>): X.Sync<R & R1, E | E1, A1> =>
       X.accessM((r: R & R1) =>
         X.chain_(f, (t) => X.provideAll_(ma, mergeEnvironments(_, r, t)))
@@ -125,7 +125,7 @@ export function provideServiceM<T extends AnyService>(_: Tag<T>) {
  * Provides the service with the required Service Entry
  */
 export function provideService<T extends AnyService>(_: Tag<T>) {
-  return (f: T) =>
+  return (f: ServiceConstructor<T>) =>
     <R1, E1, A1>(ma: X.Sync<R1 & Has<T>, E1, A1>): X.Sync<R1, E1, A1> =>
       provideServiceM(_)(X.succeed(f))(ma)
 }
@@ -135,7 +135,7 @@ export function provideService<T extends AnyService>(_: Tag<T>) {
  */
 export function replaceServiceM<R, E, T extends AnyService>(
   _: Tag<T>,
-  f: (_: T) => X.Sync<R, E, T>
+  f: (_: T) => X.Sync<R, E, ServiceConstructor<T>>
 ) {
   return <R1, E1, A1>(
     ma: X.Sync<R1 & Has<T>, E1, A1>
@@ -149,7 +149,7 @@ export function replaceServiceM<R, E, T extends AnyService>(
 export function replaceServiceM_<R, E, T extends AnyService, R1, E1, A1>(
   ma: X.Sync<R1 & Has<T>, E1, A1>,
   _: Tag<T>,
-  f: (_: T) => X.Sync<R, E, T>
+  f: (_: T) => X.Sync<R, E, ServiceConstructor<T>>
 ): X.Sync<R & R1 & Has<T>, E | E1, A1> {
   return accessServiceM(_)((t) => provideServiceM(_)(f(t))(ma))
 }
@@ -157,7 +157,10 @@ export function replaceServiceM_<R, E, T extends AnyService, R1, E1, A1>(
 /**
  * Replaces the service with the required Service Entry
  */
-export function replaceService<T extends AnyService>(_: Tag<T>, f: (_: T) => T) {
+export function replaceService<T extends AnyService>(
+  _: Tag<T>,
+  f: (_: T) => ServiceConstructor<T>
+) {
   return <R1, E1, A1>(ma: X.Sync<R1 & Has<T>, E1, A1>): X.Sync<R1 & Has<T>, E1, A1> =>
     accessServiceM(_)((t) => provideServiceM(_)(X.succeed(f(t)))(ma))
 }
@@ -168,7 +171,7 @@ export function replaceService<T extends AnyService>(_: Tag<T>, f: (_: T) => T) 
 export function replaceService_<R1, E1, A1, T extends AnyService>(
   ma: X.Sync<R1 & Has<T>, E1, A1>,
   _: Tag<T>,
-  f: (_: T) => T
+  f: (_: T) => ServiceConstructor<T>
 ): X.Sync<R1 & Has<T>, E1, A1> {
   return accessServiceM(_)((t) => provideServiceM(_)(X.succeed(f(t)))(ma))
 }

--- a/packages/system/src/Testing/TestClock/index.ts
+++ b/packages/system/src/Testing/TestClock/index.ts
@@ -449,7 +449,7 @@ export function live(data: Data) {
       )
     )
 
-    const testClock = TestClock.of(test)
+    const testClock = TestClock.has(test)
 
     return testClock as Has<Clock.Clock> & Has<TestClock>
   })["|>"](L.fromRawManaged)


### PR DESCRIPTION
- removes hidden merge behaviour for overridable services
- rename `Tag.of` to `Tag.has`
- introduce `Tag.of` as plain constructor
- relax requirements to specify serviceId when creating services

Further:
The relaxed behaviour could be ported to provideService/M & layer fromEffect/fromMnaged