### PR TITLE
Async collectAll environment fix

### DIFF
--- a/packages/core/test/async.test.ts
+++ b/packages/core/test/async.test.ts
@@ -76,7 +76,7 @@ describe("Async", () => {
     ).toEqual(As.failExit("reject"))
   })
 
-  it("preserves envioronment in collectAll", async () => {
+  it("preserves environment in collectAll", async () => {
     const succeedOne = As.access<{ readonly one: 1 }, 1>((r) => r.one)
 
     expect(

--- a/packages/core/test/async.test.ts
+++ b/packages/core/test/async.test.ts
@@ -75,4 +75,16 @@ describe("Async", () => {
       )
     ).toEqual(As.failExit("reject"))
   })
+
+  it("preserves envioronment in collectAll", async () => {
+    const succeedOne = As.access<{ readonly one: 1 }, 1>((r) => r.one)
+
+    expect(
+      await pipe(
+        As.collectAll([succeedOne, succeedOne]),
+        As.provideAll({ one: 1 as const }),
+        As.runPromiseExit
+      )
+    ).toEqual(As.successExit([1, 1]))
+  })
 })

--- a/packages/system/src/Async/core.ts
+++ b/packages/system/src/Async/core.ts
@@ -431,7 +431,9 @@ export function runPromiseExitEnv<R, E, A>(
           break
         }
         case "All": {
-          const exits = await Promise.all(xp.self.map((a) => runPromiseExit(a, is)))
+          const exits = await Promise.all(
+            xp.self.map((a) => runPromiseExitEnv(a, r, is))
+          )
           const as = []
           let errored = false
           for (let i = 0; i < exits.length && !errored; i += 1) {


### PR DESCRIPTION
# Description
Currently, the environment is lost when running variants of `IAll` in async. This PR creates a test (which currently fails) for the preservation of environments when running these computations and provides a bug fix. All tests pass in this PR.

# Results from test with current code
<img width="594" alt="Screen Shot 2021-11-11 at 8 32 05 AM" src="https://user-images.githubusercontent.com/87831824/141335175-183233e4-aca5-4c6e-98e4-57effb0b5a21.png">


