### PR TITLE
Add implementation of `stripMargin` to string module

### DIFF
--- a/packages/core/src/String/index.ts
+++ b/packages/core/src/String/index.ts
@@ -427,3 +427,136 @@ export function replace_(s: string, test: string | RegExp, r: string): string {
 export function replace(test: string | RegExp, r: string): (s: string) => string {
   return (s) => s.replace(test, r)
 }
+
+export class LinesIterator implements IterableIterator<string> {
+  /**
+   * Represents the character code of a carriage return character (`"\r"`).
+   */
+  static CR = 0x0d
+
+  /**
+   * Represents the character code of a line-feed character (`"\n"`).
+   */
+  static LF = 0x0a
+
+  private index: number
+  private length: number
+
+  constructor(readonly s: string, readonly stripped: boolean = false) {
+    this.index = 0
+    this.length = s.length
+  }
+
+  next(): IteratorResult<string> {
+    if (this.done()) {
+      return { done: true, value: undefined }
+    }
+
+    const start = this.index
+
+    while (!this.done() && !this.isLineBreak(this.s[this.index]!)) {
+      this.index = this.index + 1
+    }
+
+    let end = this.index
+
+    if (!this.done()) {
+      const char = this.s[this.index]!
+
+      this.index = this.index + 1
+
+      if (!this.done() && this.isLineBreak2(char, this.s[this.index]!)) {
+        this.index = this.index + 1
+      }
+
+      if (!this.stripped) {
+        end = this.index
+      }
+    }
+
+    return { done: false, value: this.s.substring(start, end) }
+  }
+
+  [Symbol.iterator](): IterableIterator<string> {
+    return new LinesIterator(this.s, this.stripped)
+  }
+
+  private done(): boolean {
+    return this.index >= this.length
+  }
+
+  /**
+   * Test if the provided character is a line break character (i.e. either `"\r"`
+   * or `"\n"`).
+   */
+  private isLineBreak(char: string): boolean {
+    const code = char.charCodeAt(0)
+    return code === LinesIterator.CR || code === LinesIterator.LF
+  }
+
+  /**
+   * Test if the provided characters combine to form a carriage return/line-feed
+   * (i.e. `"\r\n"`).
+   */
+  private isLineBreak2(char0: string, char1: string): boolean {
+    return (
+      char0.charCodeAt(0) === LinesIterator.CR &&
+      char1.charCodeAt(0) === LinesIterator.LF
+    )
+  }
+}
+
+function linesSeparated(s: string, stripped: boolean): LinesIterator {
+  return new LinesIterator(s, stripped)
+}
+
+export function linesIterator(s: string): LinesIterator {
+  return linesSeparated(s, true)
+}
+
+export function linesWithSeparators(s: string): LinesIterator {
+  return linesSeparated(s, false)
+}
+
+/**
+ * For every line in this string, strip a leading prefix consisting of blanks
+ * or control characters followed by the `"|"` character from the line.
+ */
+export function stripMargin(str: string): string {
+  return stripMarginWith_(str, "|")
+}
+
+/**
+ * For every line in this string, strip a leading prefix consisting of blanks
+ * or control characters followed by the `"|"` character from the line.
+ */
+export function stripMarginWith_(str: string, marginChar: string): string {
+  let out = ""
+
+  for (const line of linesWithSeparators(str)) {
+    let index = 0
+
+    while (index < line.length && line.charAt(index) <= " ") {
+      index += 1
+    }
+
+    const stripped =
+      index < line.length && line.charAt(index) === marginChar
+        ? line.substring(index + 1)
+        : line
+
+    out += stripped
+  }
+
+  return out
+}
+
+/**
+ * For every line in this string, strip a leading prefix consisting of blanks
+ * or control characters followed by the `"|"` character from the line.
+ *
+ * @ets_data_first stripMarginWith_
+ */
+export function stripMarginWith(marginChar: string) {
+  return (str: string): string => stripMarginWith_(str, marginChar)
+}

--- a/packages/core/test/string.test.ts
+++ b/packages/core/test/string.test.ts
@@ -1,0 +1,28 @@
+import * as String from "../src/String"
+
+describe("String", () => {
+  it("should strip a leading prefix from each line", () => {
+    const actual = String.stripMargin(
+      `|
+       |Hello,
+       |World!
+       |`
+    )
+    const expected = "\nHello,\nWorld!\n"
+
+    expect(actual).toBe(expected)
+  })
+
+  it("should strip a leading prefix from each line using a margin character", () => {
+    const actual = String.stripMarginWith_(
+      `$
+       $Hello,
+       $World!
+       $`,
+      "$"
+    )
+    const expected = "\nHello,\nWorld!\n"
+
+    expect(actual).toBe(expected)
+  })
+})


### PR DESCRIPTION
This PR adds an implementation of `stripMargin` to the `String` module in core. 

For reference, please refer to the Scala implementation [here](https://github.com/scala/scala/blob/d96b8eb48e83d400c03663a05b66ec218ead9c14/src/library/scala/collection/immutable/StringLike.scala#L181) (used as a reference for this implementation).

It can be used as follows:

```typescript
import * as String from "@effect-ts/core/String"

const stripped = String.stripMargin(
`|
 |Hello,
 |World!
 |`
)

expect(stripped).toEqual("\nHello,\nWorld!\n")
```

The `marginChar` defaults to `"|"` as it does in Scala, but can be overridden using the `stripMarginWith` combinator.