### PR TITLE
Initial pass at forEach and forEachPar in Async

### DIFF
--- a/packages/system/src/Async/core.ts
+++ b/packages/system/src/Async/core.ts
@@ -162,12 +162,14 @@ export class InterruptionState {
   }
 
   interrupt() {
-    // set to interrupted
-    this.isInterrupted = true
-    // notify
-    this.listeners.forEach((i) => {
-      i()
-    })
+    if (!this.isInterrupted) {
+      // set to interrupted
+      this.isInterrupted = true
+      // notify
+      this.listeners.forEach((i) => {
+        i()
+      })
+    }
   }
 }
 

--- a/packages/system/src/Async/excl-forEach.ts
+++ b/packages/system/src/Async/excl-forEach.ts
@@ -1,0 +1,272 @@
+// ets_tracing: off
+import * as ChunkFilterMap from "../Collections/Immutable/Chunk/api/filterMap"
+import * as Chunk from "../Collections/Immutable/Chunk/core"
+import { identity, pipe } from "../Function"
+import * as I from "../Iterable"
+import type * as O from "../Option"
+import type { Async } from "./core"
+import * as core from "./core"
+
+/**
+ * Applies the function `f` to each element of the `Iterable<A>` and
+ * returns the results in a new `Chunk<B>`.
+ *
+ * For a parallel version of this method, see `forEachPar`.
+ * If you do not need the results, see `forEachUnit` for a more efficient implementation.
+ */
+export function forEach_<A, R, E, B>(
+  as: Iterable<A>,
+  f: (a: A) => Async<R, E, B>
+): Async<R, E, Chunk.Chunk<B>> {
+  return core.suspend(() => {
+    const acc: B[] = []
+
+    return core.map_(
+      forEachUnit_(as, (a) =>
+        core.map_(f(a), (b) => {
+          acc.push(b)
+        })
+      ),
+      () => Chunk.from(acc)
+    )
+  })
+}
+
+/**
+ * Applies the function `f` to each element of the `Iterable<A>` and
+ * returns the results in a new `readonly B[]`.
+ *
+ * For a parallel version of this method, see `forEachPar`.
+ * If you do not need the results, see `forEachUnit` for a more efficient implementation.
+ *
+ * @ets_data_first forEach_
+ */
+export function forEach<A, R, E, B>(f: (a: A) => Async<R, E, B>) {
+  return (as: Iterable<A>) => forEach_(as, f)
+}
+
+function forEachUnitLoop<R, E, A, X>(
+  iterator: Iterator<A, any, undefined>,
+  f: (a: A) => Async<R, E, X>
+): Async<R, E, void> {
+  const next = iterator.next()
+  return next.done
+    ? core.unit
+    : core.chain_(f(next.value), () => forEachUnitLoop(iterator, f))
+}
+
+/**
+ * Applies the function `f` to each element of the `Iterable<A>` and runs
+ * produced effects sequentially.
+ *
+ * Equivalent to `asUnit(forEach(as, f))`, but without the cost of building
+ * the list of results.
+ */
+export function forEachUnit_<R, E, A, X>(
+  as: Iterable<A>,
+  f: (a: A) => Async<R, E, X>
+): Async<R, E, void> {
+  return core.suspend(() => forEachUnitLoop(as[Symbol.iterator](), f))
+}
+
+/**
+ * Applies the function `f` to each element of the `Iterable<A>` and runs
+ * produced effects sequentially.
+ *
+ * Equivalent to `asUnit(forEach(as, f))`, but without the cost of building
+ * the list of results.
+ *
+ * @ets_data_first forEachUnit_
+ */
+export function forEachUnit<R, E, A, X>(
+  f: (a: A) => Async<R, E, X>
+): (as: Iterable<A>) => Async<R, E, void> {
+  return (as) => forEachUnit_(as, f)
+}
+
+/**
+ * Applies the function `f` to each element of the `Iterable<A>` and runs
+ * produced effects in parallel, discarding the results.
+ *
+ * For a sequential version of this method, see `forEach_`.
+ *
+ * Optimized to avoid keeping full tree of effects, so that method could be
+ * able to handle large input sequences.
+ *
+ * Additionally, interrupts all effects on any failure.
+ */
+export function forEachUnitPar_<R, E, A, X>(
+  as: Iterable<A>,
+  f: (a: A) => Async<R, E, X>,
+  __trace?: string
+): Async<R, E, void> {
+  return pipe(
+    core.environment<R>(),
+    core.chain((env) =>
+      core.promise(
+        (onInterrupt) => {
+          return new Promise((resolve, reject) => {
+            const is = new core.InterruptionState()
+            const promises: Array<Promise<void>> = []
+            onInterrupt(() => {
+              if (!is.interrupted) {
+                is.interrupt()
+              }
+            })
+
+            Array.from(as).forEach((a) => {
+              promises.push(
+                core.runPromiseExitEnv(f(a), env, is).then((ex) => {
+                  if (ex._tag === "Failure") {
+                    is.interrupt()
+                    reject(ex.e)
+                  }
+                })
+              )
+            })
+            Promise.all(promises).then(() => {
+              resolve()
+            })
+          })
+        },
+        (e: unknown) => e as E
+      )
+    )
+  )
+}
+
+/**
+ * Applies the function `f` to each element of the `Iterable<A>` and runs
+ * produced effects in parallel, discarding the results.
+ *
+ * For a sequential version of this method, see `forEach_`.
+ *
+ * Optimized to avoid keeping full tree of effects, so that method could be
+ * able to handle large input sequences.
+ * Behaves almost like this code:
+ *
+ * Additionally, interrupts all effects on any failure.
+ *
+ * @ets_data_first forEachUnitPar_
+ */
+export function forEachUnitPar<R, E, A, X>(f: (a: A) => Async<R, E, X>) {
+  return (as: Iterable<A>) => forEachUnitPar_(as, f)
+}
+
+/**
+ * Applies the function `f` to each element of the `Iterable<A>` in parallel,
+ * and returns the results in a new `readonly B[]`.
+ *
+ * For a sequential version of this method, see `forEach`.
+ */
+export function forEachPar_<R, E, A, B>(
+  as: Iterable<A>,
+  f: (a: A) => Async<R, E, B>
+): Async<R, E, Chunk.Chunk<B>> {
+  return core.suspend(() =>
+    core.chain_(
+      core.succeedWith<B[]>(() => []),
+      (array) =>
+        core.map_(
+          forEachUnitPar_(
+            I.map_(as, (a, n) => [a, n] as [A, number]),
+            ([a, n]) =>
+              core.chain_(
+                core.suspend(() => f(a)),
+                (b) =>
+                  core.succeedWith(() => {
+                    array[n] = b
+                  })
+              )
+          ),
+          () => Chunk.from(array)
+        )
+    )
+  )
+}
+
+/**
+ * Applies the function `f` to each element of the `Iterable<A>` in parallel,
+ * and returns the results in a new `readonly B[]`.
+ *
+ * For a sequential version of this method, see `forEach`.
+ *
+ * @ets_data_first forEachPar_
+ */
+export function forEachPar<R, E, A, B>(f: (a: A) => Async<R, E, B>) {
+  return (as: Iterable<A>): Async<R, E, Chunk.Chunk<B>> => forEachPar_(as, f)
+}
+
+/**
+ * Evaluate each effect in the structure from left to right, and collect the
+ * results. For a parallel version, see `collectAllPar`.
+ */
+export function collectAll<R, E, A>(as: Iterable<Async<R, E, A>>) {
+  return forEach_(as, identity)
+}
+
+/**
+ * Evaluate each effect in the structure in parallel, and collect the
+ * results. For a sequential version, see `collectAll`.
+ */
+export function collectAllPar<R, E, A>(as: Iterable<Async<R, E, A>>, __trace?: string) {
+  return forEachPar_(as, identity)
+}
+
+/**
+ * Evaluate each effect in the structure from left to right, and discard the
+ * results. For a parallel version, see `collectAllUnitPar`.
+ */
+export function collectAllUnit<R, E, A>(as: Iterable<Async<R, E, A>>) {
+  return forEachUnit_(as, identity)
+}
+
+/**
+ * Evaluate each effect in the structure in parallel, and discard the
+ * results. For a sequential version, see `collectAllUnit`.
+ */
+export function collectAllUnitPar<R, E, A>(as: Iterable<Async<R, E, A>>) {
+  return forEachUnitPar_(as, identity)
+}
+
+/**
+ * Evaluate each effect in the structure with `collectAll`, and collect
+ * the results with given partial function.
+ */
+export function collectAllWith_<R, E, A, B>(
+  as: Iterable<Async<R, E, A>>,
+  pf: (a: A) => O.Option<B>
+): Async<R, E, Chunk.Chunk<B>> {
+  return core.map_(collectAll(as), ChunkFilterMap.filterMap(pf))
+}
+
+/**
+ * Evaluate each effect in the structure with `collectAll`, and collect
+ * the results with given partial function.
+ *
+ * @ets_data_first collectAllWith_
+ */
+export function collectAllWith<A, B>(pf: (a: A) => O.Option<B>) {
+  return <R, E>(as: Iterable<Async<R, E, A>>) => collectAllWith_(as, pf)
+}
+
+/**
+ * Evaluate each effect in the structure with `collectAll`, and collect
+ * the results with given partial function.
+ */
+export function collectAllWithPar_<R, E, A, B>(
+  as: Iterable<Async<R, E, A>>,
+  pf: (a: A) => O.Option<B>
+): Async<R, E, Chunk.Chunk<B>> {
+  return core.map_(collectAllPar(as), ChunkFilterMap.filterMap(pf))
+}
+
+/**
+ * Evaluate each effect in the structure with `collectAll`, and collect
+ * the results with given partial function.
+ *
+ * @ets_data_first collectAllWithPar_
+ */
+export function collectAllWithPar<A, B>(pf: (a: A) => O.Option<B>) {
+  return <R, E>(as: Iterable<Async<R, E, A>>) => collectAllWithPar_(as, pf)
+}

--- a/packages/system/src/Async/excl-forEach.ts
+++ b/packages/system/src/Async/excl-forEach.ts
@@ -34,7 +34,7 @@ export function forEach_<A, R, E, B>(
 
 /**
  * Applies the function `f` to each element of the `Iterable<A>` and
- * returns the results in a new `readonly B[]`.
+ * returns the results in a new `Chunk<B>`.
  *
  * For a parallel version of this method, see `forEachPar`.
  * If you do not need the results, see `forEachUnit` for a more efficient implementation.
@@ -97,8 +97,7 @@ export function forEachUnit<R, E, A, X>(
  */
 export function forEachUnitPar_<R, E, A, X>(
   as: Iterable<A>,
-  f: (a: A) => Async<R, E, X>,
-  __trace?: string
+  f: (a: A) => Async<R, E, X>
 ): Async<R, E, void> {
   return pipe(
     core.environment<R>(),
@@ -109,9 +108,7 @@ export function forEachUnitPar_<R, E, A, X>(
             const is = new core.InterruptionState()
             const promises: Array<Promise<void>> = []
             onInterrupt(() => {
-              if (!is.interrupted) {
-                is.interrupt()
-              }
+              is.interrupt()
             })
 
             Array.from(as).forEach((a) => {
@@ -155,7 +152,7 @@ export function forEachUnitPar<R, E, A, X>(f: (a: A) => Async<R, E, X>) {
 
 /**
  * Applies the function `f` to each element of the `Iterable<A>` in parallel,
- * and returns the results in a new `readonly B[]`.
+ * and returns the results in a new `Chunk<B>`.
  *
  * For a sequential version of this method, see `forEach`.
  */
@@ -187,7 +184,7 @@ export function forEachPar_<R, E, A, B>(
 
 /**
  * Applies the function `f` to each element of the `Iterable<A>` in parallel,
- * and returns the results in a new `readonly B[]`.
+ * and returns the results in a new `Chunk<B>`.
  *
  * For a sequential version of this method, see `forEach`.
  *
@@ -209,7 +206,7 @@ export function collectAll<R, E, A>(as: Iterable<Async<R, E, A>>) {
  * Evaluate each effect in the structure in parallel, and collect the
  * results. For a sequential version, see `collectAll`.
  */
-export function collectAllPar<R, E, A>(as: Iterable<Async<R, E, A>>, __trace?: string) {
+export function collectAllPar<R, E, A>(as: Iterable<Async<R, E, A>>) {
   return forEachPar_(as, identity)
 }
 

--- a/packages/system/src/Async/index.ts
+++ b/packages/system/src/Async/index.ts
@@ -7,4 +7,6 @@ import "../Operator"
  */
 export * from "./core"
 export * from "./derive"
+export * from "./excl-forEach"
 export * from "./has"
+export * from "./tuple"

--- a/packages/system/src/Async/tuple.ts
+++ b/packages/system/src/Async/tuple.ts
@@ -2,7 +2,6 @@
 
 import type { NonEmptyArray } from "../Collections/Immutable/NonEmptyArray"
 import * as Tp from "../Collections/Immutable/Tuple"
-import { accessCallTrace } from "../Tracing"
 import type { _E, _R, ForcedTuple } from "../Utils"
 import type { Async } from "./core"
 import { map_ } from "./core"
@@ -31,5 +30,5 @@ export function tuple<T extends NonEmptyArray<Async<any, any, any>>>(
 export function tuplePar<T extends NonEmptyArray<Async<any, any, any>>>(
   ...t: T
 ): Async<_R<T[number]>, _E<T[number]>, ForcedTuple<TupleA<T>>> {
-  return map_(collectAllPar(t, accessCallTrace()), (x) => Tp.tuple(...x)) as any
+  return map_(collectAllPar(t), (x) => Tp.tuple(...x)) as any
 }

--- a/packages/system/src/Async/tuple.ts
+++ b/packages/system/src/Async/tuple.ts
@@ -1,0 +1,35 @@
+// ets_tracing: off
+
+import type { NonEmptyArray } from "../Collections/Immutable/NonEmptyArray"
+import * as Tp from "../Collections/Immutable/Tuple"
+import { accessCallTrace } from "../Tracing"
+import type { _E, _R, ForcedTuple } from "../Utils"
+import type { Async } from "./core"
+import { map_ } from "./core"
+import { collectAll, collectAllPar } from "./excl-forEach"
+
+export type TupleA<T extends NonEmptyArray<Async<any, any, any>>> = {
+  [K in keyof T]: [T[K]] extends [Async<any, any, infer A>] ? A : never
+}
+
+/**
+ * Like `forEach` + `identity` with a tuple type
+ *
+ * @ets_trace call
+ */
+export function tuple<T extends NonEmptyArray<Async<any, any, any>>>(
+  ...t: T
+): Async<_R<T[number]>, _E<T[number]>, ForcedTuple<TupleA<T>>> {
+  return map_(collectAll(t), (x) => Tp.tuple(...x)) as any
+}
+
+/**
+ * Like sequenceT but parallel, same as `forEachPar` + `identity` with a tuple type
+ *
+ * @ets_trace call
+ */
+export function tuplePar<T extends NonEmptyArray<Async<any, any, any>>>(
+  ...t: T
+): Async<_R<T[number]>, _E<T[number]>, ForcedTuple<TupleA<T>>> {
+  return map_(collectAllPar(t, accessCallTrace()), (x) => Tp.tuple(...x)) as any
+}


### PR DESCRIPTION
This is an initial pass at adding `forEach` and `forEachPar` variants into the `Async` module in order to more closely resemble the api of `effect`. This would be a breaking change.

Not expecting this to be a final draft but I wanted to get your thoughts before I spent any more time on it.