### PR TITLE
Fix: HashMap hasHash_

### DIFF
--- a/packages/system/src/Collections/Immutable/HashMap/core.ts
+++ b/packages/system/src/Collections/Immutable/HashMap/core.ts
@@ -189,7 +189,7 @@ export function get<K>(key: K) {
  * Does an entry exist for `key` in `map`? Uses custom `hash`.
  */
 export function hasHash_<K, V>(map: HashMap<K, V>, key: K, hash: number): boolean {
-  return O.isNone(tryGetHash_(map, key, hash))
+  return O.isSome(tryGetHash_(map, key, hash))
 }
 
 /**

--- a/packages/system/test/collections/hashmap.test.ts
+++ b/packages/system/test/collections/hashmap.test.ts
@@ -1,0 +1,12 @@
+import { hash } from "@effect-ts/system/Structural"
+
+import * as HM from "../../src/Collections/Immutable/HashMap"
+import { pipe } from "../../src/Function"
+
+describe("HashMap", () => {
+  it("hasHash_", () => {
+    expect(HM.hasHash_(pipe(HM.make<number, number>(), HM.set(0, 0)), 0, hash(0))).toBe(
+      true
+    )
+  })
+})


### PR DESCRIPTION
This PR fixes the `hashHash_` function in the `HashMap` collection and adds a test for it (which fails against the existing code).