### PR TITLE
fix(exp-stream,exp-channel): missing T.transplants for zipWithLatest, mergeWith

### DIFF
--- a/packages/system/src/Experimental/Stream/Channel/api/mergeWith.ts
+++ b/packages/system/src/Experimental/Stream/Channel/api/mergeWith.ts
@@ -71,24 +71,16 @@ export function mergeWith_<
     M.bind("pullL", ({ queueReader }) => ToPull.toPull(queueReader[">>>"](self))),
     M.bind("pullR", ({ queueReader }) => ToPull.toPull(queueReader[">>>"](that))),
     M.chain(({ input, pullL, pullR, queueReader }) =>
-      M.gen(function* (_) {
-        const transplant = yield* _(
-          M.fromEffect(
-            T.transplant((graft) =>
-              T.succeed({
-                pullL: graft(pullL),
-                pullR: graft(pullR)
-              })
-            )
-          )
+      T.toManaged(
+        T.transplant((graft) =>
+          T.succeed({
+            input,
+            pullL: graft(pullL),
+            pullR: graft(pullR),
+            queueReader
+          })
         )
-        return {
-          input,
-          pullL: transplant.pullL,
-          pullR: transplant.pullR,
-          queueReader
-        }
-      })
+      )
     ),
     M.map(({ input, pullL, pullR }) => {
       type MergeState = MH.MergeState<


### PR DESCRIPTION
Initial idea to use `T.transplant` came from @r-cyr, I moved the transplant up so it would apply for the entire zip. 

I am not sure what kind of test I should add for this @mikearnaldi? I think the case we're solving by grafting is one where a `Stream` isn't closed, which I don't have a clue how to craft a test case that's supposed to end after a while.