### PR TITLE
feat(fiberref): polymorphic FiberRef

### DIFF
--- a/packages/system/src/Effect/primitives.ts
+++ b/packages/system/src/Effect/primitives.ts
@@ -8,7 +8,7 @@ import type { FiberContext } from "../Fiber/context"
 import type * as Fiber from "../Fiber/core"
 import type { FiberID } from "../Fiber/id"
 import type { Trace } from "../Fiber/tracing"
-import type { FiberRef } from "../FiberRef/fiberRef"
+import type { Runtime } from "../FiberRef/fiberRef"
 import type * as O from "../Option"
 import type { Scope } from "../Scope"
 import type { Supervisor } from "../Supervisor"
@@ -271,7 +271,7 @@ export class ISuspendPartial<R, E, A, E2> extends Base<R, E | E2, A> {
   }
 }
 
-export class IFiberRefNew<A> extends Base<unknown, never, FiberRef<A>> {
+export class IFiberRefNew<A> extends Base<unknown, never, Runtime<A>> {
   readonly _tag = "FiberRefNew"
 
   constructor(
@@ -287,7 +287,7 @@ export class IFiberRefModify<A, B> extends Base<unknown, never, B> {
   readonly _tag = "FiberRefModify"
 
   constructor(
-    readonly fiberRef: FiberRef<A>,
+    readonly fiberRef: Runtime<A>,
     readonly f: (a: A) => Tuple<[B, A]>,
     readonly trace?: string
   ) {

--- a/packages/system/src/Fiber/context.ts
+++ b/packages/system/src/Fiber/context.ts
@@ -13,7 +13,7 @@ import * as E from "../Either"
 // exit
 import * as Exit from "../Exit/api"
 // fiberRef
-import { FiberRef } from "../FiberRef/fiberRef"
+import * as FR from "../FiberRef/fiberRef"
 import * as update from "../FiberRef/update"
 import { constVoid } from "../Function"
 // option
@@ -37,7 +37,7 @@ import * as Status from "./status"
 import type { TraceElement } from "./tracing"
 import { SourceLocation, Trace, traceLocation, truncatedParentTrace } from "./tracing"
 
-export type FiberRefLocals = Map<FiberRef<any>, any>
+export type FiberRefLocals = Map<FR.Runtime<any>, any>
 
 export class Stack<A> {
   constructor(readonly value: A, readonly previous?: Stack<A>) {}
@@ -154,7 +154,7 @@ export class FiberContext<E, A> implements Fiber.Runtime<E, A> {
     }
   }
 
-  getRef<K>(fiberRef: FiberRef<K>): T.UIO<K> {
+  getRef<K>(fiberRef: FR.Runtime<K>): T.UIO<K> {
     return T.succeedWith(() => this.fiberRefLocals.get(fiberRef) || fiberRef.initial)
   }
 
@@ -1187,7 +1187,7 @@ export class FiberContext<E, A> implements Fiber.Runtime<E, A> {
                   }
 
                   case "FiberRefNew": {
-                    const fiberRef = new FiberRef(
+                    const fiberRef = new FR.Runtime(
                       current.initial,
                       current.onFork,
                       current.onJoin

--- a/packages/system/src/Fiber/core.ts
+++ b/packages/system/src/Fiber/core.ts
@@ -5,7 +5,7 @@ import { done } from "../Effect/done"
 import type { IO, UIO } from "../Effect/effect"
 import { tap_ } from "../Effect/tap"
 import type * as Exit from "../Exit/core"
-import type { FiberRef } from "../FiberRef/fiberRef"
+import type * as FR from "../FiberRef/fiberRef"
 import type * as O from "../Option"
 import type { Scope } from "../Scope"
 import type { FiberID } from "./id"
@@ -51,7 +51,7 @@ export interface CommonFiber<E, A> {
    * Gets the value of the fiber ref for this fiber, or the initial value of
    * the fiber ref, if the fiber is not storing the ref.
    */
-  getRef: <K>(fiberRef: FiberRef<K>) => UIO<K>
+  getRef: <K>(fiberRef: FR.Runtime<K>) => UIO<K>
   /**
    * Inherits values from all {@link FiberRef} instances into current fiber.
    * This will resume immediately.
@@ -90,7 +90,7 @@ export class Synthetic<E, A> implements CommonFiber<E, A> {
 
   constructor(
     _await: UIO<Exit.Exit<E, A>>,
-    readonly getRef: <K>(fiberRef: FiberRef<K>) => UIO<K>,
+    readonly getRef: <K>(fiberRef: FR.Runtime<K>) => UIO<K>,
     readonly inheritRefs: UIO<void>,
     readonly interruptAs: (fiberId: FiberID) => UIO<Exit.Exit<E, A>>,
     readonly poll: UIO<O.Option<Exit.Exit<E, A>>>

--- a/packages/system/src/Fiber/fiberName.ts
+++ b/packages/system/src/Fiber/fiberName.ts
@@ -1,10 +1,10 @@
 // ets_tracing: off
 
-import { FiberRef } from "../FiberRef"
+import { Runtime } from "../FiberRef"
 import { identity } from "../Function"
 import * as O from "../Option"
 
 /**
  * A `FiberRef` that stores the name of the fiber, which defaults to `None`.
  */
-export const fiberName = new FiberRef<O.Option<string>>(O.none, identity, identity)
+export const fiberName = new Runtime<O.Option<string>>(O.none, identity, identity)

--- a/packages/system/src/FiberRef/excl-effect.ts
+++ b/packages/system/src/FiberRef/excl-effect.ts
@@ -1,0 +1,5 @@
+export * from "../Effect/absolve"
+export * from "../Effect/bracket"
+export * from "../Effect/core"
+export * from "../Effect/fail"
+export * from "../Effect/primitives"

--- a/packages/system/src/FiberRef/fiberRef.ts
+++ b/packages/system/src/FiberRef/fiberRef.ts
@@ -1,9 +1,339 @@
 // ets_tracing: off
+import * as Tp from "../Collections/Immutable/Tuple"
+import * as E from "../Either"
+import { identity, pipe } from "../Function"
+import * as T from "./excl-effect"
 
-export class FiberRef<A> {
+export const TypeId = Symbol()
+export type TypeId = typeof TypeId
+
+export interface XFiberRef<EA, EB, A, B> {
+  /**
+   * Folds over the error and value types of the `FiberRef`. This is a highly
+   * polymorphic method that is capable of arbitrarily transforming the error
+   * and value types of the `FiberRef`. For most use cases one of the more
+   * specific combinators implemented in terms of `fold` will be more ergonomic
+   * but this method is extremely useful for implementing new combinators.
+   */
+  readonly fold: <EC, ED, C, D>(
+    ea: (_: EA) => EC,
+    eb: (_: EB) => ED,
+    ca: (_: C) => E.Either<EC, A>,
+    bd: (_: B) => E.Either<ED, D>
+  ) => XFiberRef<EC, ED, C, D>
+
+  /**
+   * Folds over the error and value types of the `FiberRef`, allowing access
+   * to the state in transforming the `set` value. This is a more powerful
+   * version of `fold` but requires unifying the error types.
+   */
+  readonly foldAll: <EC, ED, C, D>(
+    ea: (_: EA) => EC,
+    eb: (_: EB) => ED,
+    ec: (_: EB) => EC,
+    ca: (_: C) => (_: B) => E.Either<EC, A>,
+    bd: (_: B) => E.Either<ED, D>
+  ) => XFiberRef<EC, ED, C, D>
+
+  /**
+   * Reads the value associated with the current fiber. Returns initial value if
+   * no value was `set` or inherited from parent.
+   */
+  readonly get: T.IO<EB, B>
+
+  /**
+   * Returns an `IO` that runs with `value` bound to the current fiber.
+   *
+   * Guarantees that fiber data is properly restored via `bracket`.
+   */
+  readonly locally: (
+    value: A
+  ) => <R, EC, C>(use: T.Effect<R, EC, C>) => T.Effect<R, EA | EC, C>
+
+  /**
+   * Sets the value associated with the current fiber.
+   */
+  readonly set: (value: A) => T.IO<EA, void>
+}
+
+export class Runtime<A> implements XFiberRef<never, never, A, A> {
+  readonly _tag = "Runtime"
+  readonly _typeId: TypeId = TypeId
+  readonly _EA!: () => never
+  readonly _EB!: () => never
+  readonly _A!: (_: A) => void
+  readonly _B!: () => A
+
   constructor(
     readonly initial: A,
-    readonly fork: (a: A) => A,
-    readonly join: (a: A, a1: A) => A
+    readonly fork: (_: A) => A = identity,
+    readonly join: (a: A, a1: A) => A = (_, a) => a
   ) {}
+
+  fold<EC, ED, C, D>(
+    _ea: (_: never) => EC,
+    _eb: (_: never) => ED,
+    ca: (_: C) => E.Either<EC, A>,
+    bd: (_: A) => E.Either<ED, D>
+  ): XFiberRef<EC, ED, C, D> {
+    return new Derived((f) => f(this, bd, ca))
+  }
+
+  foldAll<EC, ED, C, D>(
+    _ea: (_: never) => EC,
+    _eb: (_: never) => ED,
+    _ec: (_: never) => EC,
+    ca: (_: C) => (_: A) => E.Either<EC, A>,
+    bd: (_: A) => E.Either<ED, D>
+  ): XFiberRef<EC, ED, C, D> {
+    return new DerivedAll<EC, ED, C, D>((f) =>
+      f(
+        this,
+        (s) => bd(s),
+        (c) => (s) => ca(c)(s)
+      )
+    )
+  }
+
+  modify<B>(f: (a: A) => Tp.Tuple<[B, A]>): T.UIO<B> {
+    return new T.IFiberRefModify(this, f)
+  }
+
+  get get(): T.UIO<A> {
+    return this.modify((v) => Tp.tuple(v, v))
+  }
+
+  locally(a: A): <R, EC, C>(use: T.Effect<R, EC, C>) => T.Effect<R, EC, C> {
+    return (use) =>
+      T.chain_(this.get, (oldValue) =>
+        T.bracket_(
+          this.set(a),
+          () => use,
+          () => this.set(oldValue)
+        )
+      )
+  }
+
+  set(value: A): T.UIO<void> {
+    return this.modify(() => Tp.tuple(undefined, value))
+  }
+}
+
+export class Derived<EA, EB, A, B> implements XFiberRef<EA, EB, A, B> {
+  readonly _tag = "Derived"
+  readonly _typeId: TypeId = TypeId
+  readonly _EA!: () => EA
+  readonly _EB!: () => EB
+  readonly _A!: (_: A) => void
+  readonly _B!: () => B
+
+  constructor(
+    readonly use: <X>(
+      f: <S>(
+        value: Runtime<S>,
+        getEither: (s: S) => E.Either<EB, B>,
+        setEither: (a: A) => E.Either<EA, S>
+      ) => X
+    ) => X
+  ) {}
+
+  fold<EC, ED, C, D>(
+    ea: (_: EA) => EC,
+    eb: (_: EB) => ED,
+    ca: (_: C) => E.Either<EC, A>,
+    bd: (_: B) => E.Either<ED, D>
+  ): XFiberRef<EC, ED, C, D> {
+    return this.use(
+      (value, getEither, setEither) =>
+        new Derived<EC, ED, C, D>((f) =>
+          f(
+            value,
+            (s) => E.fold_(getEither(s), (e) => E.left(eb(e)), bd),
+            (c) =>
+              E.chain_(ca(c), (a) =>
+                E.fold_(setEither(a), (e) => E.left(ea(e)), E.right)
+              )
+          )
+        )
+    )
+  }
+
+  foldAll<EC, ED, C, D>(
+    ea: (_: EA) => EC,
+    eb: (_: EB) => ED,
+    ec: (_: EB) => EC,
+    ca: (_: C) => (_: B) => E.Either<EC, A>,
+    _bd: (_: B) => E.Either<ED, D>
+  ): XFiberRef<EC, ED, C, D> {
+    return this.use(
+      (value, getEither, setEither) =>
+        new DerivedAll<EC, ED, C, D>((f) =>
+          f(
+            value,
+            (s) =>
+              E.fold_(getEither(s), (e) => E.left(eb(e)), E.right) as E.Either<ED, D>,
+            (c) => (s) =>
+              pipe(
+                getEither(s),
+                E.fold((e) => E.widenA<A>()(E.left(ec(e))), ca(c)),
+                E.chain((a) =>
+                  pipe(
+                    setEither(a),
+                    E.fold((e) => E.left(ea(e)), E.right)
+                  )
+                )
+              )
+          )
+        )
+    )
+  }
+
+  get get(): T.IO<EB, B> {
+    return this.use((value, getEither) =>
+      pipe(
+        value.get,
+        T.chain((s) => pipe(getEither(s), E.fold(T.fail, T.succeed)))
+      )
+    )
+  }
+
+  locally(a: A) {
+    return <R, EC, C>(use: T.Effect<R, EC, C>): T.Effect<R, EA | EC, C> =>
+      this.use((value, _getEither, setEither) =>
+        T.chain_(value.get, (old) =>
+          E.fold_(
+            setEither(a),
+            (e) => T.fail(e) as T.IO<EA | EC, never>,
+            (s) =>
+              pipe(
+                value.set(s),
+                T.bracket(
+                  () => use,
+                  () => value.set(old)
+                )
+              )
+          )
+        )
+      )
+  }
+
+  set(a: A): T.IO<EA, void> {
+    return this.use((value, _getEither, setEither) =>
+      E.fold_(setEither(a), T.fail, (s) => value.set(s))
+    )
+  }
+}
+
+export class DerivedAll<EA, EB, A, B> implements XFiberRef<EA, EB, A, B> {
+  readonly _tag = "DerivedAll"
+  readonly _typeId: TypeId = TypeId
+  readonly _EA!: () => EA
+  readonly _EB!: () => EB
+  readonly _A!: (_: A) => void
+  readonly _B!: () => B
+
+  constructor(
+    readonly use: <X>(
+      f: <S>(
+        value: Runtime<S>,
+        getEither: (s: S) => E.Either<EB, B>,
+        setEither: (a: A) => (s: S) => E.Either<EA, S>
+      ) => X
+    ) => X
+  ) {}
+
+  fold<EC, ED, C, D>(
+    ea: (_: EA) => EC,
+    eb: (_: EB) => ED,
+    ca: (_: C) => E.Either<EC, A>,
+    bd: (_: B) => E.Either<ED, D>
+  ): XFiberRef<EC, ED, C, D> {
+    return this.use(
+      (value, getEither, setEither) =>
+        new DerivedAll<EC, ED, C, D>((f) =>
+          f(
+            value,
+            (s) => E.fold_(getEither(s), (e) => E.left(eb(e)), bd),
+            (c) => (s) =>
+              E.chain_(ca(c), (a) =>
+                E.fold_(setEither(a)(s), (e) => E.left(ea(e)), E.right)
+              )
+          )
+        )
+    )
+  }
+
+  foldAll<EC, ED, C, D>(
+    ea: (_: EA) => EC,
+    eb: (_: EB) => ED,
+    ec: (_: EB) => EC,
+    ca: (_: C) => (_: B) => E.Either<EC, A>,
+    bd: (_: B) => E.Either<ED, D>
+  ): XFiberRef<EC, ED, C, D> {
+    return this.use(
+      (value, getEither, setEither) =>
+        new DerivedAll<EC, ED, C, D>((f) =>
+          f(
+            value,
+            (s) => E.fold_(getEither(s), (e) => E.left(eb(e)), bd),
+            (c) => (s) =>
+              pipe(
+                getEither(s),
+                E.fold((e) => E.widenA<A>()(E.left(ec(e))), ca(c)),
+                E.chain((a) => E.fold_(setEither(a)(s), (e) => E.left(ea(e)), E.right))
+              )
+          )
+        )
+    )
+  }
+
+  get get(): T.IO<EB, B> {
+    return this.use((value, getEither) =>
+      pipe(
+        value.get,
+        T.chain((s) => pipe(getEither(s), E.fold(T.fail, T.succeed)))
+      )
+    )
+  }
+
+  locally(a: A) {
+    return <R, EC, C>(use: T.Effect<R, EC, C>): T.Effect<R, EA | EC, C> =>
+      this.use((value, _getEither, setEither) =>
+        T.chain_(value.get, (old) =>
+          E.fold_(
+            setEither(a)(old),
+            (e) => T.fail(e) as T.IO<EA | EC, never>,
+            (s) =>
+              pipe(
+                value.set(s),
+                T.bracket(
+                  () => use,
+                  () => value.set(old)
+                )
+              )
+          )
+        )
+      )
+  }
+
+  set(a: A): T.IO<EA, void> {
+    return this.use((value, _getEither, setEither) =>
+      T.absolve(
+        value.modify((s) =>
+          E.fold_(
+            setEither(a)(s),
+            (e) => Tp.tuple(E.leftW<EA, void>(e), s),
+            (s) => Tp.tuple(E.right(undefined), s)
+          )
+        )
+      )
+    )
+  }
+}
+
+/**
+ * @ets_optimize identity
+ */
+export function concrete<EA, EB, A, B>(_: XFiberRef<EA, EB, A, B>) {
+  return _ as Runtime<A | B> | Derived<EA, EB, A, B> | DerivedAll<EA, EB, A, B>
 }

--- a/packages/system/src/FiberRef/fiberRef.ts
+++ b/packages/system/src/FiberRef/fiberRef.ts
@@ -331,6 +331,8 @@ export class DerivedAll<EA, EB, A, B> implements XFiberRef<EA, EB, A, B> {
   }
 }
 
+export interface FiberRef<A> extends XFiberRef<never, never, A, A> {}
+
 /**
  * @ets_optimize identity
  */

--- a/packages/system/src/FiberRef/get.ts
+++ b/packages/system/src/FiberRef/get.ts
@@ -1,12 +1,12 @@
 // ets_tracing: off
 
-import * as Tp from "../Collections/Immutable/Tuple"
-import type { UIO } from "../Effect/primitives"
-import type { FiberRef } from "./fiberRef"
-import { modify } from "./modify"
+import type { IO } from "../Effect/primitives"
+import type { XFiberRef } from "./fiberRef"
 
 /**
  * Reads the value associated with the current fiber. Returns initial value if
  * no value was `set` or inherited from parent.
  */
-export const get: <A>(fiberRef: FiberRef<A>) => UIO<A> = modify((a) => Tp.tuple(a, a))
+export function get<EA, EB, A, B>(fiberRef: XFiberRef<EA, EB, A, B>): IO<EB, B> {
+  return fiberRef.get
+}

--- a/packages/system/src/FiberRef/index.ts
+++ b/packages/system/src/FiberRef/index.ts
@@ -3,12 +3,12 @@
 import "../Operator"
 
 /**
- * Ported from https://github.com/zio/zio/blob/master/core/shared/src/main/scala/zio/FiberRef.scala
+ * Ported from https://github.com/zio/zio/blob/series/2.x/core/shared/src/main/scala/zio/ZFiberRef.scala
  *
  * Copyright 2020 Michael Arnaldi and the Matechs Garage Contributors.
  */
 
-// codegen:start {preset: barrel, include: ./*.ts}
+// codegen:start {preset: barrel, include: ./*.ts, exclude: ./excl-*.ts}
 export * from "./fiberRef"
 export * from "./get"
 export * from "./getAndSet"

--- a/packages/system/src/FiberRef/locally.ts
+++ b/packages/system/src/FiberRef/locally.ts
@@ -4,12 +4,24 @@ import type { Effect } from "../Effect/effect"
 import type { XFiberRef } from "./fiberRef"
 
 /**
- * Returns an `IO` that runs with `value` bound to the current fiber.
+ * Returns an `Effect` that runs with `value` bound to the current fiber.
+ *
+ * Guarantees that fiber data is properly restored via `bracket`.
+ *
+ * @ets_data_first locally_
+ */
+export function locally<A>(value: A) {
+  return <EA, EB, B>(
+    fiberRef: XFiberRef<EA, EB, A, B>
+  ): (<R, E, C>(effect: Effect<R, E, C>) => Effect<R, EA | E, C>) =>
+    locally_(fiberRef, value)
+}
+
+/**
+ * Returns an `Effect` that runs with `value` bound to the current fiber.
  *
  * Guarantees that fiber data is properly restored via `bracket`.
  */
-export const locally =
-  <A>(value: A) =>
-  <R, E, C>(use: Effect<R, E, C>) =>
-  <EA, EB, B>(fiberRef: XFiberRef<EA, EB, A, B>): Effect<R, EA | E, C> =>
-    fiberRef.locally(value)(use)
+export function locally_<EA, EB, A, B>(fiberRef: XFiberRef<EA, EB, A, B>, value: A) {
+  return <R, E, C>(effect: Effect<R, E, C>) => fiberRef.locally(value, effect)
+}

--- a/packages/system/src/FiberRef/locally.ts
+++ b/packages/system/src/FiberRef/locally.ts
@@ -1,12 +1,7 @@
 // ets_tracing: off
 
-import { bracket_ } from "../Effect/bracket"
-import { chain } from "../Effect/core"
 import type { Effect } from "../Effect/effect"
-import { pipe } from "../Function"
-import type { FiberRef } from "./fiberRef"
-import { get } from "./get"
-import { set } from "./set"
+import type { XFiberRef } from "./fiberRef"
 
 /**
  * Returns an `IO` that runs with `value` bound to the current fiber.
@@ -15,15 +10,6 @@ import { set } from "./set"
  */
 export const locally =
   <A>(value: A) =>
-  <R, E, B>(use: Effect<R, E, B>) =>
-  (fiberRef: FiberRef<A>): Effect<R, E, B> =>
-    pipe(
-      get(fiberRef),
-      chain((oldValue) =>
-        bracket_(
-          set(value)(fiberRef),
-          () => use,
-          () => set(oldValue)(fiberRef)
-        )
-      )
-    )
+  <R, E, C>(use: Effect<R, E, C>) =>
+  <EA, EB, B>(fiberRef: XFiberRef<EA, EB, A, B>): Effect<R, EA | E, C> =>
+    fiberRef.locally(value)(use)

--- a/packages/system/src/FiberRef/make.ts
+++ b/packages/system/src/FiberRef/make.ts
@@ -3,7 +3,7 @@
 import type { UIO } from "../Effect/effect"
 import { IFiberRefNew } from "../Effect/primitives"
 import { identity } from "../Function"
-import { FiberRef } from "./fiberRef"
+import { Runtime } from "./fiberRef"
 
 /**
  * Creates a new `FiberRef` with given initial value.
@@ -12,7 +12,7 @@ export function make<A>(
   initial: A,
   onFork: (a: A) => A = identity,
   onJoin: (a: A, a2: A) => A = (_, a) => a
-): UIO<FiberRef<A>> {
+): UIO<Runtime<A>> {
   return new IFiberRefNew(initial, onFork, onJoin)
 }
 
@@ -23,6 +23,6 @@ export function unsafeMake<A>(
   initial: A,
   onFork: (a: A) => A = identity,
   onJoin: (a: A, a2: A) => A = (_, a) => a
-): FiberRef<A> {
-  return new FiberRef(initial, onFork, onJoin)
+): Runtime<A> {
+  return new Runtime(initial, onFork, onJoin)
 }

--- a/packages/system/src/FiberRef/modify.ts
+++ b/packages/system/src/FiberRef/modify.ts
@@ -1,9 +1,12 @@
 // ets_tracing: off
 
-import type { Tuple } from "../Collections/Immutable/Tuple"
-import type { UIO } from "../Effect/effect"
-import { IFiberRefModify } from "../Effect/primitives"
-import type { FiberRef } from "./fiberRef"
+import * as Tp from "../Collections/Immutable/Tuple"
+import * as E from "../Either"
+import { pipe } from "../Function"
+import { matchTag } from "../Utils"
+import * as T from "./excl-effect"
+import type { XFiberRef } from "./fiberRef"
+import { concrete } from "./fiberRef"
 
 /**
  * Atomically modifies the `FiberRef` with the specified function, which computes
@@ -12,8 +15,9 @@ import type { FiberRef } from "./fiberRef"
  *
  * @ets_data_first modify_
  */
-export function modify<A, B>(f: (a: A) => Tuple<[B, A]>) {
-  return (fiberRef: FiberRef<A>): UIO<B> => new IFiberRefModify(fiberRef, f)
+export function modify<A, B>(f: (a: A) => Tp.Tuple<[B, A]>) {
+  return <EA, EB>(fiberRef: XFiberRef<EA, EB, A, A>): T.IO<EA | EB, B> =>
+    modify_(fiberRef, f)
 }
 
 /**
@@ -21,9 +25,66 @@ export function modify<A, B>(f: (a: A) => Tuple<[B, A]>) {
  * a return value for the modification. This is a more powerful version of
  * `update`.
  */
-export function modify_<A, B>(
-  fiberRef: FiberRef<A>,
-  f: (a: A) => Tuple<[B, A]>
-): UIO<B> {
-  return new IFiberRefModify(fiberRef, f)
+export function modify_<EA, EB, A, B>(
+  fiberRef: XFiberRef<EA, EB, A, A>,
+  f: (a: A) => Tp.Tuple<[B, A]>
+): T.IO<EA | EB, B> {
+  return pipe(
+    fiberRef,
+    concrete,
+    matchTag({
+      Runtime: (self) => self.modify(f),
+      Derived: (self) =>
+        self.use((value, getEither, setEither) =>
+          pipe(
+            value.modify((s) =>
+              pipe(
+                s,
+                getEither,
+                E.fold(
+                  (e) => Tp.tuple(E.left(e), s),
+                  (a1) =>
+                    pipe(f(a1), ({ tuple: [b, a2] }) =>
+                      pipe(
+                        a2,
+                        setEither,
+                        E.fold(
+                          (e) => Tp.tuple(E.left(e), s),
+                          (s) => Tp.tuple(E.widenE<EA | EB>()(E.right(b)), s)
+                        )
+                      )
+                    )
+                )
+              )
+            ),
+            T.absolve
+          )
+        ),
+      DerivedAll: (self) =>
+        self.use((value, getEither, setEither) =>
+          pipe(
+            value.modify((s) =>
+              pipe(
+                s,
+                getEither,
+                E.fold(
+                  (e) => Tp.tuple(E.left(e), s),
+                  (a1) =>
+                    pipe(f(a1), ({ tuple: [b, a2] }) =>
+                      pipe(
+                        setEither(a2)(s),
+                        E.fold(
+                          (e) => Tp.tuple(E.left(e), s),
+                          (s) => Tp.tuple(E.widenE<EA | EB>()(E.right(b)), s)
+                        )
+                      )
+                    )
+                )
+              )
+            ),
+            T.absolve
+          )
+        )
+    })
+  )
 }

--- a/packages/system/src/FiberRef/set.ts
+++ b/packages/system/src/FiberRef/set.ts
@@ -1,25 +1,20 @@
 // ets_tracing: off
 
-import * as Tp from "../Collections/Immutable/Tuple"
-import type { UIO } from "../Effect/effect"
-import { pipe } from "../Function"
-import type { FiberRef } from "./fiberRef"
-import { modify } from "./modify"
+import type { IO } from "../Effect/effect"
+import type { XFiberRef } from "./fiberRef"
+
 /**
  * Sets the value associated with the current fiber.
  *
  * @ets_data_first set_
  */
 export function set<A>(a: A) {
-  return (fiberRef: FiberRef<A>): UIO<void> => set_(fiberRef, a)
+  return <EA, EB>(fiberRef: XFiberRef<EA, EB, A, A>): IO<EA, void> => set_(fiberRef, a)
 }
 
 /**
  * Sets the value associated with the current fiber.
  */
-export function set_<A>(fiberRef: FiberRef<A>, a: A): UIO<void> {
-  return pipe(
-    fiberRef,
-    modify((_) => Tp.tuple(undefined, a))
-  )
+export function set_<EA, EB, A>(fiberRef: XFiberRef<EA, EB, A, A>, a: A): IO<EA, void> {
+  return fiberRef.set(a)
 }

--- a/packages/system/src/FiberRef/update.ts
+++ b/packages/system/src/FiberRef/update.ts
@@ -1,7 +1,7 @@
 // ets_tracing: off
 
 import * as Tp from "../Collections/Immutable/Tuple"
-import type { FiberRef } from "./fiberRef"
+import type { XFiberRef } from "./fiberRef"
 import { modify_ } from "./modify"
 
 /**
@@ -10,12 +10,12 @@ import { modify_ } from "./modify"
  * @ets_data_first update_
  */
 export function update<A>(f: (a: A) => A) {
-  return (self: FiberRef<A>) => update_(self, f)
+  return <EA, EB>(self: XFiberRef<EA, EB, A, A>) => update_(self, f)
 }
 
 /**
  * Atomically modifies the `FiberRef` with the specified function.
  */
-export function update_<A>(self: FiberRef<A>, f: (a: A) => A) {
+export function update_<EA, EB, A>(self: XFiberRef<EA, EB, A, A>, f: (a: A) => A) {
   return modify_(self, (v) => Tp.tuple<[void, A]>(undefined, f(v)))
 }

--- a/packages/system/src/Testing/Annotations/index.ts
+++ b/packages/system/src/Testing/Annotations/index.ts
@@ -67,27 +67,23 @@ export const live = L.fromEffect(Annotations)(
       self: T.Effect<R, E, A>
     ) => T.Effect<R, Annotated<E>, Annotated<A>> = (effect) =>
       pipe(
-        fiberRef,
-        FiberRef.locally(TAM.TestAnnotationMap.empty)(
-          pipe(
-            effect,
-            T.foldM(
-              (e) =>
-                pipe(
-                  fiberRef,
-                  FiberRef.get,
-                  T.map((_) => Tuple.tuple(e, _)),
-                  T.flip
-                ),
-              (a) =>
-                pipe(
-                  fiberRef,
-                  FiberRef.get,
-                  T.map((_) => Tuple.tuple(a, _))
-                )
+        effect,
+        T.foldM(
+          (e) =>
+            pipe(
+              fiberRef,
+              FiberRef.get,
+              T.map((_) => Tuple.tuple(e, _)),
+              T.flip
+            ),
+          (a) =>
+            pipe(
+              fiberRef,
+              FiberRef.get,
+              T.map((_) => Tuple.tuple(a, _))
             )
-          )
-        )
+        ),
+        FiberRef.locally_(fiberRef, TAM.TestAnnotationMap.empty)
       )
 
     const supervisedFibers = T.descriptorWith((d) =>

--- a/packages/system/test/effect.test.ts
+++ b/packages/system/test/effect.test.ts
@@ -287,7 +287,7 @@ describe("Effect", () => {
     expect(result).toEqual(Ex.fail("(error)"))
   })
   it("fiberRef", async () => {
-    const fa = pipe(T.environment<FiberRef.FiberRef<boolean>>(), T.chain(FiberRef.get))
+    const fa = pipe(T.environment<FiberRef.Runtime<boolean>>(), T.chain(FiberRef.get))
     const result = await pipe(
       FiberRef.make(true, (_) => _),
       T.tap((ref) => FiberRef.set_(ref, false)),

--- a/packages/system/test/fiberRef.test.ts
+++ b/packages/system/test/fiberRef.test.ts
@@ -1,0 +1,317 @@
+import { provideTestClock } from "../src/Clock"
+import * as Tp from "../src/Collections/Immutable/Tuple"
+import * as T from "../src/Effect"
+import * as F from "../src/Fiber"
+import * as FR from "../src/FiberRef"
+import { identity, increment, pipe } from "../src/Function"
+import * as O from "../src/Option"
+import * as P from "../src/Promise"
+import { runTest } from "./utils/runTest"
+
+describe("FiberRef", () => {
+  const initial = "initial"
+  const update = "update"
+  const update1 = "update1"
+  const update2 = "update2"
+  it("`get` returns the current valye", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(initial)
+    })["|>"](runTest))
+
+  it("`get` returns the current value for a child", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const child = yield* _(pipe(FR.get(fiberRef), T.fork))
+      const value = yield* _(F.join(child))
+      expect(value).toEqual(initial)
+    })["|>"](runTest))
+
+  it("`getAndUpdate` changes value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const value1 = yield* _(
+        pipe(
+          fiberRef,
+          FR.getAndUpdate(() => update1)
+        )
+      )
+      const value2 = yield* _(FR.get(fiberRef))
+      expect(value1).toEqual(initial)
+      expect(value2).toEqual(update1)
+    })["|>"](runTest))
+
+  it("`getAndUpdateSome` changes value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const value1 = yield* _(
+        pipe(
+          fiberRef,
+          FR.getAndUpdateSome(() => O.some(update1))
+        )
+      )
+      const value2 = yield* _(FR.get(fiberRef))
+      expect(value1).toEqual(initial)
+      expect(value2).toEqual(update1)
+    })["|>"](runTest))
+
+  it("`getAndUpdateSome` doesn't changes value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const value1 = yield* _(
+        pipe(
+          fiberRef,
+          FR.getAndUpdateSome(
+            O.partial((miss) => (x) => x !== initial ? update1 : miss())
+          )
+        )
+      )
+      const value2 = yield* _(FR.get(fiberRef))
+      expect(value1).toEqual(initial)
+      expect(value2).toEqual(initial)
+    })["|>"](runTest))
+
+  it("`locally` restores original value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const local = yield* _(pipe(fiberRef, FR.locally(update1)(FR.get(fiberRef))))
+      const value = yield* _(FR.get(fiberRef))
+      expect(local).toEqual(update1)
+      expect(value).toEqual(initial)
+      return
+    })["|>"](runTest))
+
+  it("`locally` restores parent's value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const child = yield* _(
+        pipe(fiberRef, FR.locally(update1)(FR.get(fiberRef)), T.fork)
+      )
+      const local = yield* _(F.join(child))
+      const value = yield* _(FR.get(fiberRef))
+      expect(local).toEqual(update1)
+      expect(value).toEqual(initial)
+    })["|>"](runTest))
+
+  it("`locally` restores undefined value", () =>
+    T.gen(function* (_) {
+      const child = yield* _(pipe(FR.make(initial), T.fork))
+      const fiberRef = yield* _(pipe(child, F.await, T.chain(T.done)))
+      const localValue = yield* _(pipe(fiberRef, FR.locally(update1)(FR.get(fiberRef))))
+      const value = yield* _(FR.get(fiberRef))
+      expect(localValue).toEqual(update1)
+      expect(value).toEqual(initial)
+    })["|>"](runTest))
+
+  it("`modify` changes value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const value1 = yield* _(
+        pipe(
+          fiberRef,
+          FR.modify(() => Tp.tuple(1, update1))
+        )
+      )
+      const value2 = yield* _(FR.get(fiberRef))
+      expect(value1).toEqual(1)
+      expect(value2).toEqual(update1)
+    })["|>"](runTest))
+
+  it("`modifySome` doesn't change value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const value1 = yield* _(
+        pipe(
+          fiberRef,
+          FR.modifySome(() => 2)(
+            O.partial((miss) => (x) => x !== initial ? Tp.tuple(1, update1) : miss())
+          )
+        )
+      )
+      const value2 = yield* _(FR.get(fiberRef))
+      expect(value1).toEqual(2)
+      expect(value2).toEqual(initial)
+    })["|>"](runTest))
+
+  it("`set` updates the current value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      yield* _(pipe(fiberRef, FR.set(update1)))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(update1)
+    })["|>"](runTest))
+
+  it("`set` by a child doesn't update the parent's value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const promise = yield* _(P.make<never, void>())
+      yield* _(
+        pipe(
+          fiberRef,
+          FR.set(update1),
+          T.zipRight(pipe(promise, P.succeed<void>(undefined))),
+          T.fork
+        )
+      )
+      yield* _(P.await(promise))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(initial)
+    })["|>"](runTest))
+
+  it("`updateAndGet` changes value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const value1 = yield* _(
+        pipe(
+          fiberRef,
+          FR.updateAndGet(() => update1)
+        )
+      )
+      const value2 = yield* _(FR.get(fiberRef))
+      expect(value1).toEqual(update1)
+      expect(value2).toEqual(update1)
+    })["|>"](runTest))
+
+  it("`updateSomeAndGet` changes value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const value1 = yield* _(
+        pipe(
+          fiberRef,
+          FR.updateSomeAndGet(() => O.some(update1))
+        )
+      )
+      const value2 = yield* _(pipe(FR.get(fiberRef)))
+      expect(value1).toEqual(update1)
+      expect(value2).toEqual(update1)
+    })["|>"](runTest))
+
+  it("`updateSomeAndGet` doesn't change value", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const value1 = yield* _(
+        pipe(
+          fiberRef,
+          FR.updateSomeAndGet(
+            O.partial((miss) => (x) => x !== initial ? update1 : miss())
+          )
+        )
+      )
+      const value2 = yield* _(pipe(FR.get(fiberRef)))
+      expect(value1).toEqual(initial)
+      expect(value2).toEqual(initial)
+    })["|>"](runTest))
+
+  it("value is inherited after simple race", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      yield* _(pipe(fiberRef, FR.set(update1), T.race(pipe(fiberRef, FR.set(update2)))))
+      const value = yield* _(fiberRef.get)
+      expect([update1, update2]).toContain(value)
+    })["|>"](runTest))
+
+  it("value is inherited after a race with a failed winner", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const failedWinner = pipe(fiberRef, FR.set(update1), T.zipRight(T.fail("oops")))
+      const succeededLoser = pipe(fiberRef, FR.set(update2), T.zipRight(T.sleep(0)))
+      yield* _(pipe(failedWinner, T.race(succeededLoser)))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(update2)
+    })
+      ["|>"](provideTestClock)
+      ["|>"](runTest))
+
+  it("value is not inherited after a race of two failed Effects", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const failed1 = pipe(fiberRef, FR.set(update1), T.zipRight(T.fail("oops1")))
+      const failed2 = pipe(fiberRef, FR.set(update2), T.zipRight(T.fail("oops2")))
+      yield* _(pipe(failed1, T.race(failed2), T.ignore))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(initial)
+    })["|>"](runTest))
+
+  it("the value of the loser is inherited in zipPar", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const latch = yield* _(P.make<never, void>())
+      const winner = pipe(
+        fiberRef,
+        FR.set(update1),
+        T.zipRight(pipe(latch, P.succeed<void>(undefined))),
+        T.asUnit
+      )
+      const loser = pipe(
+        P.await(latch),
+        T.zipRight(pipe(fiberRef, FR.set(update2))),
+        T.zipRight(T.sleep(0))
+      )
+      yield* _(pipe(winner, T.zipPar(loser)))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(update2)
+    })
+      ["|>"](provideTestClock)
+      ["|>"](runTest))
+
+  it("nothing get inherited with a failure in zipPar", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(initial))
+      const success = pipe(fiberRef, FR.set(update))
+      const failure1 = pipe(fiberRef, FR.set(update1), T.zipRight(T.fail("oops1")))
+      const failure2 = pipe(fiberRef, FR.set(update2), T.zipRight(T.fail("oops2")))
+      yield* _(
+        pipe(
+          success,
+          T.zipPar(failure1),
+          T.zipPar(failure2),
+          T.orElse(() => T.unit)
+        )
+      )
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(initial)
+    })["|>"](runTest))
+
+  it("fork function is applied on fork - 1", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(0, increment))
+      const child = yield* _(pipe(T.unit, T.fork))
+      yield* _(F.join(child))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(1)
+    })["|>"](runTest))
+
+  it("fork function is applied on fork - 2", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(0, increment))
+      const child = yield* _(pipe(T.unit, T.fork, T.chain(F.join), T.fork))
+      yield* _(F.join(child))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(2)
+    })["|>"](runTest))
+
+  it("join function is applied on join - 1", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(0, identity, Math.max))
+      const child = yield* _(pipe(fiberRef, FR.update(increment), T.fork))
+      yield* _(F.join(child))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(1)
+    })["|>"](runTest))
+
+  it("join function is applied on join - 2", () =>
+    T.gen(function* (_) {
+      const fiberRef = yield* _(FR.make(0, identity, Math.max))
+      const child = yield* _(pipe(fiberRef, FR.update(increment), T.fork))
+      yield* _(
+        pipe(
+          fiberRef,
+          FR.update((n) => n + 2)
+        )
+      )
+      yield* _(F.join(child))
+      const value = yield* _(FR.get(fiberRef))
+      expect(value).toEqual(2)
+    })["|>"](runTest))
+})

--- a/packages/system/test/fiberRef.test.ts
+++ b/packages/system/test/fiberRef.test.ts
@@ -75,7 +75,7 @@ describe("FiberRef", () => {
   it("`locally` restores original value", () =>
     T.gen(function* (_) {
       const fiberRef = yield* _(FR.make(initial))
-      const local = yield* _(pipe(fiberRef, FR.locally(update1)(FR.get(fiberRef))))
+      const local = yield* _(pipe(FR.get(fiberRef), FR.locally_(fiberRef, update1)))
       const value = yield* _(FR.get(fiberRef))
       expect(local).toEqual(update1)
       expect(value).toEqual(initial)
@@ -86,7 +86,7 @@ describe("FiberRef", () => {
     T.gen(function* (_) {
       const fiberRef = yield* _(FR.make(initial))
       const child = yield* _(
-        pipe(fiberRef, FR.locally(update1)(FR.get(fiberRef)), T.fork)
+        pipe(FR.get(fiberRef), FR.locally_(fiberRef, update1), T.fork)
       )
       const local = yield* _(F.join(child))
       const value = yield* _(FR.get(fiberRef))
@@ -98,7 +98,9 @@ describe("FiberRef", () => {
     T.gen(function* (_) {
       const child = yield* _(pipe(FR.make(initial), T.fork))
       const fiberRef = yield* _(pipe(child, F.await, T.chain(T.done)))
-      const localValue = yield* _(pipe(fiberRef, FR.locally(update1)(FR.get(fiberRef))))
+      const localValue = yield* _(
+        pipe(FR.get(fiberRef), FR.locally_(fiberRef, update1))
+      )
       const value = yield* _(FR.get(fiberRef))
       expect(localValue).toEqual(update1)
       expect(value).toEqual(initial)


### PR DESCRIPTION
## Summary

This PR refactors `FiberRef` in preparation for porting the updated runtime system from ZIO 2. Additionally, I ported many of the `FiberRef` tests from ZIO

This is only a port of the core, and doesn't port additional methods (`map`, `contramap`, etc.)