### PR TITLE
Add Zio 2.x implementation of TPriorityQueue

### DIFF
--- a/packages/system-next/src/Collections/Immutable/SortedMap/index.ts
+++ b/packages/system-next/src/Collections/Immutable/SortedMap/index.ts
@@ -1,0 +1,173 @@
+import { pipe } from "@effect-ts/system/Function"
+
+import * as It from "../../../Iterable"
+import type * as O from "../../../Option"
+import type * as Ord from "../../../Ord"
+import * as ST from "../../../Structural"
+import * as RB from "../RedBlackTree"
+import type * as Tp from "../Tuple"
+
+export class SortedMap<K, V> implements Iterable<readonly [K, V]> {
+  readonly _K!: () => K
+  readonly _V!: () => V
+
+  constructor(readonly tree: RB.RedBlackTree<K, V>) {}
+
+  get [ST.hashSym](): number {
+    return this.tree[ST.hashSym]
+  }
+
+  [Symbol.iterator](): Iterator<readonly [K, V]> {
+    return this.tree[Symbol.iterator]()
+  }
+
+  [ST.equalsSym](that: unknown): boolean {
+    return this.tree[ST.equalsSym](that)
+  }
+}
+
+export interface Next<A> {
+  readonly done?: boolean
+  readonly value: A
+}
+
+export function make<K, V>(o: Ord.Ord<K>): SortedMap<K, V> {
+  return new SortedMap<K, V>(RB.make(o))
+}
+
+export function get_<K, V>(map: SortedMap<K, V>, key: K): O.Option<V> {
+  return RB.findFirst_(map.tree, key)
+}
+
+/**
+ * @ets_data_first get_
+ */
+export function get<K>(key: K) {
+  return <V>(map: SortedMap<K, V>) => get_(map, key)
+}
+
+export function remove_<K, V>(map: SortedMap<K, V>, key: K): SortedMap<K, V> {
+  return new SortedMap(RB.removeFirst_(map.tree, key))
+}
+
+export function remove<K, V>(key: K) {
+  return (map: SortedMap<K, V>) => remove_(map, key)
+}
+
+export function set_<K, V>(map: SortedMap<K, V>, key: K, value: V): SortedMap<K, V> {
+  return new SortedMap(
+    RB.has_(map.tree, key)
+      ? pipe(map.tree, RB.removeFirst(key), RB.insert(key, value))
+      : RB.insert_(map.tree, key, value)
+  )
+}
+
+/**
+ * @ets_data_first set_
+ */
+export function set<K, V>(key: K, value: V) {
+  return (map: SortedMap<K, V>) => set_(map, key, value)
+}
+
+export function size<K, V>(map: SortedMap<K, V>): number {
+  return RB.size(map.tree)
+}
+
+export function empty<K, V>(ord: Ord.Ord<K>): SortedMap<K, V> {
+  return new SortedMap<K, V>(RB.make(ord))
+}
+
+export function isEmpty<K, V>(map: SortedMap<K, V>): boolean {
+  return size(map) === 0
+}
+
+export function nonEmpty<K, V>(map: SortedMap<K, V>): boolean {
+  return !isEmpty(map)
+}
+
+export function fromIterable_<K, V>(
+  ord: Ord.Ord<K>,
+  iterable: Iterable<readonly [K, V]>
+): SortedMap<K, V> {
+  return new SortedMap(RB.from(iterable, ord))
+}
+
+/**
+ * @ets_data_first fromIterable_
+ */
+export function fromIterable<K>(ord: Ord.Ord<K>) {
+  return <V>(iterable: Iterable<readonly [K, V]>) => fromIterable_(ord, iterable)
+}
+
+export function getOrd<K, V>(map: SortedMap<K, V>): Ord.Ord<K> {
+  return map.tree.ord
+}
+
+export function headOption<K, V>(map: SortedMap<K, V>): O.Option<Tp.Tuple<[K, V]>> {
+  return RB.getFirst(map.tree)
+}
+
+export function values<K, V>(map: SortedMap<K, V>): IterableIterator<V> {
+  return RB.values_(map.tree)
+}
+
+export function keys<K, V>(map: SortedMap<K, V>): IterableIterator<K> {
+  return RB.keys_(map.tree)
+}
+
+export function entries<K, V>(map: SortedMap<K, V>): Iterator<readonly [K, V]> {
+  return map[Symbol.iterator]()
+}
+
+export function mapWithIndex_<K, V, A>(
+  map: SortedMap<K, V>,
+  f: (a: V, k: K) => A
+): SortedMap<K, A> {
+  return reduceWithIndex_(map, make<K, A>(getOrd(map)), (b, a, k) =>
+    set_(b, k, f(a, k))
+  )
+}
+
+/**
+ * @ets_data_first mapWithIndex_
+ */
+export function mapWithIndex<K, V, A>(f: (a: V, k: K) => A) {
+  return (map: SortedMap<K, V>) => mapWithIndex_(map, f)
+}
+
+export function reduceWithIndex_<K, V, A>(
+  map: SortedMap<K, V>,
+  b: A,
+  f: (b: A, a: V, k: K) => A
+) {
+  return It.reduce_(map, b, (b, [k, a]) => f(b, a, k))
+}
+
+/**
+ * @ets_data_first reduceWithIndex_
+ */
+export function reduceWithIndex<K, V, A>(b: A, f: (b: A, a: V, k: K) => A) {
+  return (map: SortedMap<K, V>) => reduceWithIndex_(map, b, f)
+}
+
+export function reduce_<K, V, A>(map: SortedMap<K, V>, b: A, f: (b: A, a: V) => A) {
+  return reduceWithIndex_(map, b, (z, a) => f(z, a))
+}
+
+/**
+ * @ets_data_first reduce_
+ */
+export function reduce<K, V, A>(b: A, f: (b: A, a: V) => A) {
+  return (map: SortedMap<K, V>) => reduce_(map, b, f)
+}
+
+export function map_<K, V, A>(map: SortedMap<K, V>, f: (a: V) => A): SortedMap<K, A> {
+  return mapWithIndex_(map, (a: V, _) => f(a))
+}
+
+/**
+ * @ets_data_first map_
+ */
+export function map<K, V, A>(f: (a: V) => A) {
+  return (map: SortedMap<K, V>) => map_(map, f)
+}

--- a/packages/system-next/src/Collections/Immutable/SortedMap/index.ts
+++ b/packages/system-next/src/Collections/Immutable/SortedMap/index.ts
@@ -1,5 +1,4 @@
-import { pipe } from "@effect-ts/system/Function"
-
+import { pipe } from "../../../Function"
 import * as It from "../../../Iterable"
 import type * as O from "../../../Option"
 import type * as Ord from "../../../Ord"

--- a/packages/system-next/src/Transactional/STM/_internal/primitives.ts
+++ b/packages/system-next/src/Transactional/STM/_internal/primitives.ts
@@ -52,6 +52,8 @@ export abstract class STM<R, E, A> {
   readonly [_A]: () => A
 }
 
+export type USTM<A> = STM<unknown, never, A>
+
 export const STMEffectTypeId = Symbol.for("@effect-ts/system/STM/Effect")
 export type STMEffectTypeId = typeof STMEffectTypeId
 

--- a/packages/system-next/src/Transactional/TPriorityQueue/index.ts
+++ b/packages/system-next/src/Transactional/TPriorityQueue/index.ts
@@ -1,8 +1,9 @@
-import * as Chunk from "../../Collections/Immutable/Chunk"
+import * as Ch from "../../Collections/Immutable/Chunk"
 import * as SortedMap from "../../Collections/Immutable/SortedMap"
 import * as Tp from "../../Collections/Immutable/Tuple"
 import type { Predicate } from "../../Function"
-import { pipe } from "../../Function"
+import { not, pipe } from "../../Function"
+import * as It from "../../Iterable"
 import * as O from "../../Option"
 import type * as Ord from "../../Ord"
 import * as STM from "../STM"
@@ -13,7 +14,7 @@ export type TPriorityQueueTypeId = typeof TPriorityQueueTypeId
 
 export class TPriorityQueue<A> {
   readonly _typeId: TPriorityQueueTypeId = TPriorityQueueTypeId
-  constructor(readonly map: TRef.TRef<SortedMap.SortedMap<A, Chunk.Chunk<A>>>) {}
+  constructor(readonly map: TRef.TRef<SortedMap.SortedMap<A, Ch.Chunk<A>>>) {}
 }
 
 /**
@@ -27,6 +28,8 @@ export function make_<A>(
 }
 
 /**
+ * Makes a new `TPriorityQueue` that is initialized with specified values.
+ *
  * @ets_data_first make_
  */
 export function make<A>(...data: Array<A>) {
@@ -40,76 +43,99 @@ export function fromIterable_<A>(
   ord: Ord.Ord<A>,
   data: Iterable<A>
 ): STM.USTM<TPriorityQueue<A>> {
-  let map = SortedMap.empty<A, Chunk.Chunk<A>>(ord)
-
-  for (const a of data) {
-    map = SortedMap.set_(map, a, Chunk.single(a))
-  }
-
-  return STM.map_(TRef.make(map), (as) => new TPriorityQueue(as))
+  return pipe(
+    It.reduce_(data, SortedMap.empty<A, Ch.Chunk<A>>(ord), (map, a) =>
+      SortedMap.set_(map, a, Ch.single(a))
+    ),
+    TRef.make,
+    STM.map((as) => new TPriorityQueue(as))
+  )
 }
 
 /**
+ * Makes a new `TPriorityQueue` initialized with provided iterable.
+ *
  * @ets_data_first fromIterable_
  */
 export function fromIterable<A>(data: Iterable<A>) {
   return (ord: Ord.Ord<A>) => fromIterable_(ord, data)
 }
 
+/**
+ * Constructs a new empty `TPriorityQueue` with the specified `Ordering`.
+ */
 export function empty<A>(ord: Ord.Ord<A>): STM.USTM<TPriorityQueue<A>> {
   return STM.map_(
-    TRef.make(SortedMap.empty<A, Chunk.Chunk<A>>(ord)),
+    TRef.make(SortedMap.empty<A, Ch.Chunk<A>>(ord)),
     (as) => new TPriorityQueue(as)
   )
 }
 
+/**
+ * Checks whether the queue is empty.
+ */
 export function isEmpty<A>(self: TPriorityQueue<A>): STM.USTM<boolean> {
   return STM.map_(TRef.get(self.map), SortedMap.isEmpty)
 }
 
+/**
+ * Checks whether the queue is not empty..
+ */
 export function nonEmpty<A>(self: TPriorityQueue<A>): STM.USTM<boolean> {
   return STM.map_(TRef.get(self.map), SortedMap.nonEmpty)
 }
 
+/**
+ * Offers the specified value to the queue.
+ */
 export function offer_<A>(self: TPriorityQueue<A>, a: A): STM.USTM<void> {
   return STM.map_(
-    TRef.getAndUpdate_(self.map, SortedMap.set(a, Chunk.single(a))),
+    TRef.getAndUpdate_(self.map, SortedMap.set(a, Ch.single(a))),
     () => STM.unit
   )
 }
 
 /**
+ * Offers the specified value to the queue.
+ *
  * @ets_data_first offer_
  */
 export function offer<A>(a: A) {
   return (self: TPriorityQueue<A>) => offer_(self, a)
 }
 
+/**
+ * Offers all of the elements in the specified collection to the queue.
+ */
 export function offerAll_<A>(
   self: TPriorityQueue<A>,
   values: Iterable<A>
 ): STM.USTM<void> {
   return STM.map_(
-    TRef.getAndUpdate_(self.map, (sa) => {
-      let map = SortedMap.empty<A, Chunk.Chunk<A>>(SortedMap.getOrd(sa))
-
-      for (const a of values) {
-        map = SortedMap.set_(map, a, Chunk.single(a))
-      }
-
-      return map
-    }),
+    TRef.getAndUpdate_(self.map, (sa) =>
+      It.reduce_(
+        values,
+        SortedMap.empty<A, Ch.Chunk<A>>(SortedMap.getOrd(sa)),
+        (map, a) => SortedMap.set_(map, a, Ch.single(a))
+      )
+    ),
     () => STM.unit
   )
 }
 
 /**
+ * Offers all of the elements in the specified collection to the queue.
+ *
  * @ets_data_first offerAll_
  */
 export function offerAll<A>(a: Iterable<A>) {
   return (self: TPriorityQueue<A>) => offerAll_(self, a)
 }
 
+/**
+ * Peeks at the first value in the queue without removing it, retrying until a
+ * value is in the queue.
+ */
 export function peek<A>(self: TPriorityQueue<A>): STM.USTM<A> {
   return new STM.STMEffect((journal) =>
     pipe(
@@ -117,7 +143,7 @@ export function peek<A>(self: TPriorityQueue<A>): STM.USTM<A> {
       TRef.unsafeGet(journal),
       SortedMap.headOption,
       O.map(Tp.get(1)),
-      O.chain(Chunk.head),
+      O.chain(Ch.head),
       (o) => {
         if (o._tag === "None") {
           throw new STM.STMRetryException()
@@ -129,50 +155,83 @@ export function peek<A>(self: TPriorityQueue<A>): STM.USTM<A> {
   )
 }
 
+/**
+ * Peeks at the first value in the queue without removing it, returning `None`
+ * if there is not a value in the queue.
+ */
 export function peekOption<A>(self: TPriorityQueue<A>): STM.USTM<O.Option<A>> {
   return TRef.modify_(
     self.map,
     (map) =>
       [
-        pipe(map, SortedMap.headOption, O.map(Tp.get(1)), O.chain(Chunk.head)),
+        pipe(map, SortedMap.headOption, O.map(Tp.get(1)), O.chain(Ch.head)),
         map
       ] as const
   )
 }
 
+/**
+ * Retains only elements from the queue matching the specified predicate.
+ */
 export function retainIf_<A>(self: TPriorityQueue<A>, p: Predicate<A>): STM.USTM<void> {
-  return TRef.update_(self.map, SortedMap.map(Chunk.filter(p)))
+  return TRef.update_(self.map, SortedMap.map(Ch.filter(p)))
 }
 
 /**
+ * Retains only elements from the queue matching the specified predicate.
+ *
  * @ets_data_first retainIf_
  */
 export function retainIf<A>(p: Predicate<A>) {
   return (self: TPriorityQueue<A>) => retainIf_(self, p)
 }
 
+/**
+ * Removes all elements from the queue matching the specified predicate.
+ */
+export function removeIf_<A>(self: TPriorityQueue<A>, p: Predicate<A>) {
+  return retainIf_(self, not(p))
+}
+
+/**
+ * Removes all elements from the queue matching the specified predicate.
+ *
+ * @ets_data_first removeIf_
+ */
+export function removeIf<A>(p: Predicate<A>) {
+  return (self: TPriorityQueue<A>) => removeIf_(self, p)
+}
+
+/**
+ * Returns the size of the queue.
+ */
 export function size<A>(self: TPriorityQueue<A>): STM.USTM<number> {
   return TRef.modify_(self.map, (map) => [SortedMap.size(map), map] as const)
 }
 
+/**
+ * Takes a value from the queue, retrying until a value is in the queue.
+ */
 export function take<A>(self: TPriorityQueue<A>): STM.USTM<A> {
   return new STM.STMEffect((journal) => {
-    O.gen(function* (_) {})
-    pipe(
-      self.map,
-      TRef.unsafeGet(journal),
+    const map = TRef.unsafeGet_(self.map, journal)
+
+    return pipe(
+      map,
       SortedMap.headOption,
       O.chain((tp) => {
-        const a = pipe(tp, Tp.get(1), Chunk.tail)
+        const a = pipe(tp, Tp.get(1), Ch.tail, O.chain(O.fromPredicate(Ch.isNonEmpty)))
+        const k = Tp.get_(tp, 0)
 
-        const map =
+        TRef.unsafeSet_(
+          self.map,
           a._tag === "None"
-            ? SortedMap.remove_(self.map, Tp.get_(tp, 0))
-            : SortedMap.set_(self.map, a.value)
+            ? SortedMap.remove_(map, k)
+            : SortedMap.set_(map, k, a.value),
+          journal
+        )
 
-        TRef.unsafeSet_(self.map, journal)
-
-        return Chunk.head(Tp.get_(tp, 1))
+        return Ch.head(Tp.get_(tp, 1))
       }),
       (o) => {
         if (o._tag === "None") {
@@ -182,5 +241,109 @@ export function take<A>(self: TPriorityQueue<A>): STM.USTM<A> {
         return o.value
       }
     )
+  })
+}
+
+/**
+ * Takes a value from the queue, returning `None` if there is not a value in
+ * the queue.
+ */
+export function takeOption<A>(self: TPriorityQueue<A>): STM.USTM<O.Option<A>> {
+  return new STM.STMEffect((journal) => {
+    const map = TRef.unsafeGet_(self.map, journal)
+
+    return pipe(
+      map,
+      SortedMap.headOption,
+      O.chain((tp) => {
+        const a = pipe(tp, Tp.get(1), Ch.tail, O.chain(O.fromPredicate(Ch.isNonEmpty)))
+        const k = Tp.get_(tp, 0)
+
+        TRef.unsafeSet_(
+          self.map,
+          a._tag === "None"
+            ? SortedMap.remove_(map, k)
+            : SortedMap.set_(map, k, a.value),
+          journal
+        )
+
+        return Ch.head(Tp.get_(tp, 1))
+      })
+    )
+  })
+}
+
+/**
+ * Takes all values from the queue.
+ */
+export function takeAll<A>(self: TPriorityQueue<A>): STM.USTM<Ch.Chunk<A>> {
+  return TRef.modify_(
+    self.map,
+    (map) => [SortedMap.reduce_(map, Ch.empty<A>(), Ch.concat_), map] as const
+  )
+}
+
+/**
+ * Takes up to the specified maximum number of elements from the queue.
+ */
+export function takeUpTo_<A>(
+  self: TPriorityQueue<A>,
+  n: number
+): STM.USTM<Ch.Chunk<A>> {
+  return TRef.modify_(self.map, (map) => {
+    const entries = SortedMap.entries(map)
+    const builder = Ch.builder<Ch.Chunk<A>>()
+    let updated = map
+    let e: SortedMap.Next<readonly [A, Ch.Chunk<A>]>
+    let i = 0
+
+    while (!(e = entries.next()).done) {
+      const [a, as] = e.value
+      const [l, r] = pipe(
+        as,
+        Ch.splitAt(n - i),
+        (tp) => [Tp.get_(tp, 0), Tp.get_(tp, 1)] as const
+      )
+
+      builder.append(l)
+
+      if (Ch.isEmpty(r)) {
+        updated = SortedMap.remove_(updated, a)
+      } else {
+        updated = SortedMap.set_(updated, a, r)
+      }
+
+      i += Ch.size(l)
+    }
+
+    return [Ch.flatten(builder.build()), updated] as const
+  })
+}
+
+/**
+ * Takes up to the specified maximum number of elements from the queue.
+ *
+ * @ets_data_first takeUpTo_
+ */
+export function takeUpTo(n: number) {
+  return <A>(self: TPriorityQueue<A>) => takeUpTo_(self, n)
+}
+
+/**
+ * Collects all values into a chunk.
+ */
+export function toChunk<A>(self: TPriorityQueue<A>): STM.USTM<Ch.Chunk<A>> {
+  return TRef.modify_(self.map, (map) => {
+    const entries = SortedMap.entries(map)
+    const builder = Ch.builder<Ch.Chunk<A>>()
+    let e: SortedMap.Next<readonly [A, Ch.Chunk<A>]>
+
+    while (!(e = entries.next()).done) {
+      const [, as] = e.value
+
+      builder.append(as)
+    }
+
+    return [Ch.flatten(builder.build()), map] as const
   })
 }

--- a/packages/system-next/src/Transactional/TPriorityQueue/index.ts
+++ b/packages/system-next/src/Transactional/TPriorityQueue/index.ts
@@ -1,0 +1,186 @@
+import * as Chunk from "../../Collections/Immutable/Chunk"
+import * as SortedMap from "../../Collections/Immutable/SortedMap"
+import * as Tp from "../../Collections/Immutable/Tuple"
+import type { Predicate } from "../../Function"
+import { pipe } from "../../Function"
+import * as O from "../../Option"
+import type * as Ord from "../../Ord"
+import * as STM from "../STM"
+import * as TRef from "../TRef"
+
+export const TPriorityQueueTypeId = Symbol()
+export type TPriorityQueueTypeId = typeof TPriorityQueueTypeId
+
+export class TPriorityQueue<A> {
+  readonly _typeId: TPriorityQueueTypeId = TPriorityQueueTypeId
+  constructor(readonly map: TRef.TRef<SortedMap.SortedMap<A, Chunk.Chunk<A>>>) {}
+}
+
+/**
+ * Makes a new `TPriorityQueue` that is initialized with specified values.
+ */
+export function make_<A>(
+  ord: Ord.Ord<A>,
+  ...data: Array<A>
+): STM.USTM<TPriorityQueue<A>> {
+  return fromIterable_(ord, data)
+}
+
+/**
+ * @ets_data_first make_
+ */
+export function make<A>(...data: Array<A>) {
+  return (ord: Ord.Ord<A>) => make_(ord, ...data)
+}
+
+/**
+ * Makes a new `TPriorityQueue` initialized with provided iterable.
+ */
+export function fromIterable_<A>(
+  ord: Ord.Ord<A>,
+  data: Iterable<A>
+): STM.USTM<TPriorityQueue<A>> {
+  let map = SortedMap.empty<A, Chunk.Chunk<A>>(ord)
+
+  for (const a of data) {
+    map = SortedMap.set_(map, a, Chunk.single(a))
+  }
+
+  return STM.map_(TRef.make(map), (as) => new TPriorityQueue(as))
+}
+
+/**
+ * @ets_data_first fromIterable_
+ */
+export function fromIterable<A>(data: Iterable<A>) {
+  return (ord: Ord.Ord<A>) => fromIterable_(ord, data)
+}
+
+export function empty<A>(ord: Ord.Ord<A>): STM.USTM<TPriorityQueue<A>> {
+  return STM.map_(
+    TRef.make(SortedMap.empty<A, Chunk.Chunk<A>>(ord)),
+    (as) => new TPriorityQueue(as)
+  )
+}
+
+export function isEmpty<A>(self: TPriorityQueue<A>): STM.USTM<boolean> {
+  return STM.map_(TRef.get(self.map), SortedMap.isEmpty)
+}
+
+export function nonEmpty<A>(self: TPriorityQueue<A>): STM.USTM<boolean> {
+  return STM.map_(TRef.get(self.map), SortedMap.nonEmpty)
+}
+
+export function offer_<A>(self: TPriorityQueue<A>, a: A): STM.USTM<void> {
+  return STM.map_(
+    TRef.getAndUpdate_(self.map, SortedMap.set(a, Chunk.single(a))),
+    () => STM.unit
+  )
+}
+
+/**
+ * @ets_data_first offer_
+ */
+export function offer<A>(a: A) {
+  return (self: TPriorityQueue<A>) => offer_(self, a)
+}
+
+export function offerAll_<A>(
+  self: TPriorityQueue<A>,
+  values: Iterable<A>
+): STM.USTM<void> {
+  return STM.map_(
+    TRef.getAndUpdate_(self.map, (sa) => {
+      let map = SortedMap.empty<A, Chunk.Chunk<A>>(SortedMap.getOrd(sa))
+
+      for (const a of values) {
+        map = SortedMap.set_(map, a, Chunk.single(a))
+      }
+
+      return map
+    }),
+    () => STM.unit
+  )
+}
+
+/**
+ * @ets_data_first offerAll_
+ */
+export function offerAll<A>(a: Iterable<A>) {
+  return (self: TPriorityQueue<A>) => offerAll_(self, a)
+}
+
+export function peek<A>(self: TPriorityQueue<A>): STM.USTM<A> {
+  return new STM.STMEffect((journal) =>
+    pipe(
+      self.map,
+      TRef.unsafeGet(journal),
+      SortedMap.headOption,
+      O.map(Tp.get(1)),
+      O.chain(Chunk.head),
+      (o) => {
+        if (o._tag === "None") {
+          throw new STM.STMRetryException()
+        }
+
+        return o.value
+      }
+    )
+  )
+}
+
+export function peekOption<A>(self: TPriorityQueue<A>): STM.USTM<O.Option<A>> {
+  return TRef.modify_(
+    self.map,
+    (map) =>
+      [
+        pipe(map, SortedMap.headOption, O.map(Tp.get(1)), O.chain(Chunk.head)),
+        map
+      ] as const
+  )
+}
+
+export function retainIf_<A>(self: TPriorityQueue<A>, p: Predicate<A>): STM.USTM<void> {
+  return TRef.update_(self.map, SortedMap.map(Chunk.filter(p)))
+}
+
+/**
+ * @ets_data_first retainIf_
+ */
+export function retainIf<A>(p: Predicate<A>) {
+  return (self: TPriorityQueue<A>) => retainIf_(self, p)
+}
+
+export function size<A>(self: TPriorityQueue<A>): STM.USTM<number> {
+  return TRef.modify_(self.map, (map) => [SortedMap.size(map), map] as const)
+}
+
+export function take<A>(self: TPriorityQueue<A>): STM.USTM<A> {
+  return new STM.STMEffect((journal) => {
+    O.gen(function* (_) {})
+    pipe(
+      self.map,
+      TRef.unsafeGet(journal),
+      SortedMap.headOption,
+      O.chain((tp) => {
+        const a = pipe(tp, Tp.get(1), Chunk.tail)
+
+        const map =
+          a._tag === "None"
+            ? SortedMap.remove_(self.map, Tp.get_(tp, 0))
+            : SortedMap.set_(self.map, a.value)
+
+        TRef.unsafeSet_(self.map, journal)
+
+        return Chunk.head(Tp.get_(tp, 1))
+      }),
+      (o) => {
+        if (o._tag === "None") {
+          throw new STM.STMRetryException()
+        }
+
+        return o.value
+      }
+    )
+  })
+}

--- a/packages/system-next/test/priorityQueue.test.ts
+++ b/packages/system-next/test/priorityQueue.test.ts
@@ -1,166 +1,120 @@
-import * as Tp from "../src/Collections/Immutable/Tuple"
+import * as Ch from "../src/Collections/Immutable/Chunk"
 import * as T from "../src/Effect"
-import * as Ex from "../src/Exit"
-import * as Fiber from "../src/Fiber"
-import { pipe } from "../src/Function"
-import * as Promise from "../src/Promise"
+import * as Eq from "../src/Equal"
+import { flow, pipe } from "../src/Function"
+import * as Ord from "../src/Ord"
 import * as STM from "../src/Transactional/STM"
-import * as TRef from "../src/Transactional/TRef"
-import * as TSemaphore from "../src/Transactional/TSemaphore"
+import * as TPriorityQueue from "../src/Transactional/TPriorityQueue"
 
-function repeat<E, A>(self: STM.STM<unknown, E, A>, n: number): STM.STM<unknown, E, A> {
-  if (n < 1) {
-    return STM.die(`The value of "n" must be greater than 0, received: ${n}`)
-  }
-  if (n === 1) {
-    return self
-  }
-  return STM.chain_(self, () => STM.suspend(() => repeat(self, n - 1)))
+interface Event {
+  time: number
+  description: string
 }
 
-describe("TSemaphore", () => {
-  describe("factories", () => {
-    it("make", async () => {
-      const result = await pipe(
-        TSemaphore.make(10),
-        STM.chain(TSemaphore.available),
-        STM.commit,
-        T.unsafeRunPromise
-      )
+describe("TPriorityQueue", () => {
+  const a = { time: -1, description: "aah" }
+  const b = { time: 0, description: "test" }
+  const as = Ch.make<Event[]>(a, b)
+  const eventOrd = Ord.contramap_(Ord.number, ({ time }: Event) => time)
+  const eventEq = Eq.struct({
+    time: Eq.number,
+    description: Eq.string
+  })
+  const eventPredicate = ({ description }: Event) => description === "test"
 
-      expect(result).toBe(10)
-    })
+  it("isEmpty", async () => {
+    const transaction = await pipe(
+      TPriorityQueue.empty<Event>(eventOrd),
+      STM.tap(TPriorityQueue.offerAll(as)),
+      STM.chain(TPriorityQueue.isEmpty),
+      STM.commit,
+      T.unsafeRunPromise
+    )
+
+    expect(transaction).toBe(Ch.isEmpty(as))
+  })
+  it("nonEmpty", async () => {
+    const transaction = await pipe(
+      TPriorityQueue.empty<Event>(eventOrd),
+      STM.tap(TPriorityQueue.offerAll(as)),
+      STM.chain(TPriorityQueue.nonEmpty),
+      STM.commit,
+      T.unsafeRunPromise
+    )
+
+    expect(transaction).toBe(Ch.isNonEmpty(as))
+  })
+  it("offerAll and takeAll", async () => {
+    const transaction = await pipe(
+      TPriorityQueue.empty<Event>(eventOrd),
+      STM.tap(TPriorityQueue.offerAll(as)),
+      STM.chain(TPriorityQueue.takeAll),
+      STM.commit,
+      T.unsafeRunPromise
+    )
+
+    expect(Ch.corresponds_(transaction, as, eventEq.equals)).toBe(true)
   })
 
-  describe("acquire and release", () => {
-    it("acquiring and releasing a permit should not change the availability", async () => {
-      const result = await pipe(
-        TSemaphore.make(10),
-        STM.chain((semaphore) =>
-          pipe(
-            TSemaphore.acquire(semaphore),
-            STM.chain(() => TSemaphore.release(semaphore)),
-            STM.chain(() => TSemaphore.available(semaphore))
-          )
-        ),
-        STM.commit,
-        T.unsafeRunPromise
-      )
+  it("removeIf", async () => {
+    const transaction = await pipe(
+      TPriorityQueue.fromIterable_(eventOrd, as),
+      STM.tap(TPriorityQueue.removeIf(eventPredicate)),
+      STM.chain(TPriorityQueue.toChunk),
+      STM.commit,
+      T.unsafeRunPromise
+    )
 
-      expect(result).toBe(10)
-    })
+    expect(Ch.corresponds_(transaction, Ch.single(a), eventEq.equals)).toBe(true)
+  })
 
-    it("used capacity must be equal to the # of acquires minus # of releases", async () => {
-      const capacity = 10
-      const acquire = 7
-      const release = 4
+  it("retainIf", async () => {
+    const transaction = await pipe(
+      TPriorityQueue.fromIterable_(eventOrd, as),
+      STM.tap(TPriorityQueue.retainIf(eventPredicate)),
+      STM.chain(TPriorityQueue.toChunk),
+      STM.commit,
+      T.unsafeRunPromise
+    )
 
-      const result = await pipe(
-        TSemaphore.make(capacity),
-        STM.chain((sem) =>
-          pipe(
-            repeat(TSemaphore.acquire(sem), acquire),
-            STM.chain(() => repeat(TSemaphore.release(sem), release)),
-            STM.chain(() => TSemaphore.available(sem))
-          )
-        ),
-        STM.commit,
-        T.unsafeRunPromise
-      )
+    expect(Ch.corresponds_(transaction, Ch.single(b), eventEq.equals)).toBe(true)
+  })
+  it("take", async () => {
+    const transaction = await pipe(
+      TPriorityQueue.fromIterable_(eventOrd, as),
+      STM.chain(flow(TPriorityQueue.take, STM.replicate(Ch.size(as)), STM.collectAll)),
+      STM.commit,
+      T.unsafeRunPromise
+    )
 
-      const usedCapacity = acquire - release
-
-      expect(result).toBe(capacity - usedCapacity)
-    })
-
-    it("acquireN/releaseN(n) is acquire/release repeated N times", async () => {
-      const capacity = 50
-
-      function acquireRelease(
-        sem: TSemaphore.TSemaphore,
-        acquire: (n: number) => STM.STM<unknown, never, void>,
-        release: (n: number) => STM.STM<unknown, never, void>
-      ): STM.STM<unknown, never, Tp.Tuple<[number, number]>> {
-        return STM.gen(function* (_) {
-          yield* _(acquire(50))
-
-          const usedCapacity = yield* _(TSemaphore.available(sem))
-
-          yield* _(release(capacity))
-
-          const freeCapacity = yield* _(TSemaphore.available(sem))
-
-          return Tp.tuple(usedCapacity, freeCapacity)
+    expect(Ch.corresponds_(transaction, as, eventEq.equals)).toBe(true)
+  })
+  it("takeUpTo", async () => {
+    const { left, right } = await pipe(
+      TPriorityQueue.fromIterable_(eventOrd, as),
+      STM.chain((queue) =>
+        STM.gen(function* (_) {
+          return {
+            left: yield* _(TPriorityQueue.takeUpTo_(queue, 1)),
+            right: yield* _(TPriorityQueue.takeAll(queue))
+          }
         })
-      }
+      ),
+      STM.commit,
+      T.unsafeRunPromise
+    )
 
-      const stm = STM.gen(function* (_) {
-        const sem = yield* _(TSemaphore.make(capacity))
-        const acquireReleaseN = acquireRelease(
-          sem,
-          (n) => TSemaphore.acquireN_(sem, n),
-          (n) => TSemaphore.releaseN_(sem, n)
-        )
-        const acquireReleaseRep = acquireRelease(
-          sem,
-          (n) => repeat(TSemaphore.acquire(sem), n),
-          (n) => repeat(TSemaphore.release(sem), n)
-        )
-        const resN = yield* _(acquireReleaseN)
-        const resRep = yield* _(acquireReleaseRep)
-        return { resN, resRep }
-      })
+    expect(Ch.corresponds_(left, Ch.single(a), eventEq.equals)).toBe(true)
+    expect(Ch.corresponds_(right, Ch.single(b), eventEq.equals)).toBe(true)
+  })
+  it("toChunk", async () => {
+    const transaction = await pipe(
+      TPriorityQueue.fromIterable_(eventOrd, as),
+      STM.chain(TPriorityQueue.toChunk),
+      STM.commit,
+      T.unsafeRunPromise
+    )
 
-      const { resN, resRep } = await pipe(STM.commit(stm), T.unsafeRunPromise)
-
-      expect(resN.get(0)).toBe(resRep.get(0))
-      expect(resN.get(1)).toBe(resRep.get(1))
-      expect(resN.get(0)).toBe(0)
-      expect(resN.get(1)).toBe(capacity)
-    })
-
-    it("withPermit automatically releases the permit if the effect is interrupted", async () => {
-      const { permits } = await pipe(
-        T.do,
-        T.bind("promise", () => Promise.make<never, void>()),
-        T.bind("semaphore", () => STM.commit(TSemaphore.make(1))),
-        T.let("effect", ({ promise, semaphore }) =>
-          T.chain_(
-            TSemaphore.withPermit_(Promise.succeed_(promise, undefined), semaphore),
-            () => T.never
-          )
-        ),
-        T.bind("fiber", ({ effect }) => T.fork(effect)),
-        T.tap(({ promise }) => Promise.await(promise)),
-        T.tap(({ fiber }) => Fiber.interrupt(fiber)),
-        T.bind("permits", ({ semaphore }) =>
-          pipe(TRef.get(semaphore.permits), STM.commit)
-        ),
-        T.unsafeRunPromise
-      )
-
-      expect(permits).toBe(1)
-    })
-
-    it("withPermit acquire is interruptible", async () => {
-      const f = jest.fn()
-      const res = await pipe(
-        T.do,
-        T.bind("semaphore", () => STM.commit(TSemaphore.make(0))),
-        T.let("effect", ({ semaphore }) =>
-          TSemaphore.withPermit_(
-            T.succeed(() => f()),
-            semaphore
-          )
-        ),
-        T.bind("fiber", ({ effect }) => T.fork(effect)),
-        T.tap(({ fiber }) => Fiber.interrupt(fiber)),
-        T.chain(({ fiber }) => Fiber.join(fiber)),
-        T.unsafeRunPromiseExit
-      )
-
-      expect(Ex.isInterrupted(res)).toBe(true)
-      expect(f).toHaveBeenCalledTimes(0)
-    })
+    expect(Ch.corresponds_(transaction, as, eventEq.equals)).toBe(true)
   })
 })

--- a/packages/system-next/test/priorityQueue.test.ts
+++ b/packages/system-next/test/priorityQueue.test.ts
@@ -1,0 +1,166 @@
+import * as Tp from "../src/Collections/Immutable/Tuple"
+import * as T from "../src/Effect"
+import * as Ex from "../src/Exit"
+import * as Fiber from "../src/Fiber"
+import { pipe } from "../src/Function"
+import * as Promise from "../src/Promise"
+import * as STM from "../src/Transactional/STM"
+import * as TRef from "../src/Transactional/TRef"
+import * as TSemaphore from "../src/Transactional/TSemaphore"
+
+function repeat<E, A>(self: STM.STM<unknown, E, A>, n: number): STM.STM<unknown, E, A> {
+  if (n < 1) {
+    return STM.die(`The value of "n" must be greater than 0, received: ${n}`)
+  }
+  if (n === 1) {
+    return self
+  }
+  return STM.chain_(self, () => STM.suspend(() => repeat(self, n - 1)))
+}
+
+describe("TSemaphore", () => {
+  describe("factories", () => {
+    it("make", async () => {
+      const result = await pipe(
+        TSemaphore.make(10),
+        STM.chain(TSemaphore.available),
+        STM.commit,
+        T.unsafeRunPromise
+      )
+
+      expect(result).toBe(10)
+    })
+  })
+
+  describe("acquire and release", () => {
+    it("acquiring and releasing a permit should not change the availability", async () => {
+      const result = await pipe(
+        TSemaphore.make(10),
+        STM.chain((semaphore) =>
+          pipe(
+            TSemaphore.acquire(semaphore),
+            STM.chain(() => TSemaphore.release(semaphore)),
+            STM.chain(() => TSemaphore.available(semaphore))
+          )
+        ),
+        STM.commit,
+        T.unsafeRunPromise
+      )
+
+      expect(result).toBe(10)
+    })
+
+    it("used capacity must be equal to the # of acquires minus # of releases", async () => {
+      const capacity = 10
+      const acquire = 7
+      const release = 4
+
+      const result = await pipe(
+        TSemaphore.make(capacity),
+        STM.chain((sem) =>
+          pipe(
+            repeat(TSemaphore.acquire(sem), acquire),
+            STM.chain(() => repeat(TSemaphore.release(sem), release)),
+            STM.chain(() => TSemaphore.available(sem))
+          )
+        ),
+        STM.commit,
+        T.unsafeRunPromise
+      )
+
+      const usedCapacity = acquire - release
+
+      expect(result).toBe(capacity - usedCapacity)
+    })
+
+    it("acquireN/releaseN(n) is acquire/release repeated N times", async () => {
+      const capacity = 50
+
+      function acquireRelease(
+        sem: TSemaphore.TSemaphore,
+        acquire: (n: number) => STM.STM<unknown, never, void>,
+        release: (n: number) => STM.STM<unknown, never, void>
+      ): STM.STM<unknown, never, Tp.Tuple<[number, number]>> {
+        return STM.gen(function* (_) {
+          yield* _(acquire(50))
+
+          const usedCapacity = yield* _(TSemaphore.available(sem))
+
+          yield* _(release(capacity))
+
+          const freeCapacity = yield* _(TSemaphore.available(sem))
+
+          return Tp.tuple(usedCapacity, freeCapacity)
+        })
+      }
+
+      const stm = STM.gen(function* (_) {
+        const sem = yield* _(TSemaphore.make(capacity))
+        const acquireReleaseN = acquireRelease(
+          sem,
+          (n) => TSemaphore.acquireN_(sem, n),
+          (n) => TSemaphore.releaseN_(sem, n)
+        )
+        const acquireReleaseRep = acquireRelease(
+          sem,
+          (n) => repeat(TSemaphore.acquire(sem), n),
+          (n) => repeat(TSemaphore.release(sem), n)
+        )
+        const resN = yield* _(acquireReleaseN)
+        const resRep = yield* _(acquireReleaseRep)
+        return { resN, resRep }
+      })
+
+      const { resN, resRep } = await pipe(STM.commit(stm), T.unsafeRunPromise)
+
+      expect(resN.get(0)).toBe(resRep.get(0))
+      expect(resN.get(1)).toBe(resRep.get(1))
+      expect(resN.get(0)).toBe(0)
+      expect(resN.get(1)).toBe(capacity)
+    })
+
+    it("withPermit automatically releases the permit if the effect is interrupted", async () => {
+      const { permits } = await pipe(
+        T.do,
+        T.bind("promise", () => Promise.make<never, void>()),
+        T.bind("semaphore", () => STM.commit(TSemaphore.make(1))),
+        T.let("effect", ({ promise, semaphore }) =>
+          T.chain_(
+            TSemaphore.withPermit_(Promise.succeed_(promise, undefined), semaphore),
+            () => T.never
+          )
+        ),
+        T.bind("fiber", ({ effect }) => T.fork(effect)),
+        T.tap(({ promise }) => Promise.await(promise)),
+        T.tap(({ fiber }) => Fiber.interrupt(fiber)),
+        T.bind("permits", ({ semaphore }) =>
+          pipe(TRef.get(semaphore.permits), STM.commit)
+        ),
+        T.unsafeRunPromise
+      )
+
+      expect(permits).toBe(1)
+    })
+
+    it("withPermit acquire is interruptible", async () => {
+      const f = jest.fn()
+      const res = await pipe(
+        T.do,
+        T.bind("semaphore", () => STM.commit(TSemaphore.make(0))),
+        T.let("effect", ({ semaphore }) =>
+          TSemaphore.withPermit_(
+            T.succeed(() => f()),
+            semaphore
+          )
+        ),
+        T.bind("fiber", ({ effect }) => T.fork(effect)),
+        T.tap(({ fiber }) => Fiber.interrupt(fiber)),
+        T.chain(({ fiber }) => Fiber.join(fiber)),
+        T.unsafeRunPromiseExit
+      )
+
+      expect(Ex.isInterrupted(res)).toBe(true)
+      expect(f).toHaveBeenCalledTimes(0)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the Zio 2.x implementation of TPriorityQueue, SortedMap and some missing combinators for STM.

Related to #1035

