### PR TITLE
perf: decrease atomic references

### DIFF
--- a/packages/system-next/src/Promise/definition.ts
+++ b/packages/system-next/src/Promise/definition.ts
@@ -1,10 +1,6 @@
 import type { FiberId } from "../FiberId"
-import type { AtomicReference } from "../Support/AtomicReference"
 import type { State } from "./state"
 
 export class Promise<E, A> {
-  constructor(
-    readonly state: AtomicReference<State<E, A>>,
-    readonly blockingOn: FiberId
-  ) {}
+  constructor(public state: State<E, A>, readonly blockingOn: FiberId) {}
 }

--- a/packages/system-next/src/Promise/operations/await.ts
+++ b/packages/system-next/src/Promise/operations/await.ts
@@ -8,14 +8,14 @@ import { interruptJoiner_ } from "./interruptJoiner"
 function wait<E, A>(self: Promise<E, A>, __trace?: string): IO<E, A> {
   return asyncInterruptBlockingOn(
     (k) => {
-      const state = self.state.get
+      const state = self.state
 
       switch (state._tag) {
         case "Done": {
           return E.right(state.value)
         }
         case "Pending": {
-          self.state.set(new Pending([k, ...state.joiners]))
+          self.state = new Pending([k, ...state.joiners])
           return E.left(interruptJoiner_(self, k))
         }
       }

--- a/packages/system-next/src/Promise/operations/completeWith.ts
+++ b/packages/system-next/src/Promise/operations/completeWith.ts
@@ -21,14 +21,14 @@ export function completeWith_<E, A>(
   __trace?: string
 ): UIO<boolean> {
   return succeed(() => {
-    const state = self.state.get
+    const state = self.state
 
     switch (state._tag) {
       case "Done": {
         return false
       }
       case "Pending": {
-        self.state.set(new Done(io))
+        self.state = new Done(io)
         state.joiners.forEach((f) => {
           f(io)
         })

--- a/packages/system-next/src/Promise/operations/interruptJoiner.ts
+++ b/packages/system-next/src/Promise/operations/interruptJoiner.ts
@@ -9,10 +9,10 @@ export function interruptJoiner_<E, A>(
   __trace?: string
 ): Canceler<unknown> {
   return succeed(() => {
-    const state = self.state.get
+    const state = self.state
 
     if (state._tag === "Pending") {
-      self.state.set(new Pending(state.joiners.filter((j) => j !== joiner)))
+      self.state = new Pending(state.joiners.filter((j) => j !== joiner))
     }
   }, __trace)
 }

--- a/packages/system-next/src/Promise/operations/isDone.ts
+++ b/packages/system-next/src/Promise/operations/isDone.ts
@@ -7,5 +7,5 @@ import type { Promise } from "../definition"
  * already been completed with a value or an error and false otherwise.
  */
 export function isDone<E, A>(self: Promise<E, A>, __trace?: string): UIO<boolean> {
-  return succeed(() => self.state.get._tag === "Done")
+  return succeed(() => self.state._tag === "Done")
 }

--- a/packages/system-next/src/Promise/operations/poll.ts
+++ b/packages/system-next/src/Promise/operations/poll.ts
@@ -12,7 +12,7 @@ export function poll<E, A>(
   __trace?: string
 ): UIO<O.Option<IO<E, A>>> {
   return succeed(() => {
-    const state = self.state.get
+    const state = self.state
     switch (state._tag) {
       case "Pending": {
         return O.none

--- a/packages/system-next/src/Promise/operations/unsafeDone.ts
+++ b/packages/system-next/src/Promise/operations/unsafeDone.ts
@@ -6,10 +6,10 @@ import { Done } from "../state"
  * Unsafe version of `done`.
  */
 export function unsafeDone_<E, A>(self: Promise<E, A>, io: IO<E, A>): void {
-  const state = self.state.get
+  const state = self.state
 
   if (state._tag === "Pending") {
-    self.state.set(new Done(io))
+    self.state = new Done(io)
 
     Array.from(state.joiners)
       .reverse()

--- a/packages/system-next/src/Promise/operations/unsafeMake.ts
+++ b/packages/system-next/src/Promise/operations/unsafeMake.ts
@@ -1,8 +1,7 @@
 import type { FiberId } from "../../FiberId"
-import { AtomicReference } from "../../Support/AtomicReference"
 import { Promise } from "../definition"
 import { Pending } from "../state"
 
 export function unsafeMake<E, A>(fiberId: FiberId): Promise<E, A> {
-  return new Promise(new AtomicReference(new Pending([])), fiberId)
+  return new Promise(new Pending([]), fiberId)
 }

--- a/packages/system-next/src/Ref/Atomic/Atomic.ts
+++ b/packages/system-next/src/Ref/Atomic/Atomic.ts
@@ -1,5 +1,4 @@
 import type { Either } from "../../Either"
-import type { AtomicReference } from "../../Support/AtomicReference"
 import type { XRef } from "../definition"
 import { XRefInternal } from "../definition"
 import { Derived } from "./Derived"
@@ -9,16 +8,18 @@ import * as T from "./operations/_internal/effect"
 export class Atomic<A> extends XRefInternal<unknown, unknown, never, never, A, A> {
   readonly _tag = "Atomic"
 
-  constructor(readonly value: AtomicReference<A>) {
+  constructor(public value: A) {
     super()
   }
 
   get get(): T.Effect<unknown, never, A> {
-    return T.succeed(() => this.value.get)
+    return T.succeed(() => this.value)
   }
 
   set(a: A): T.Effect<unknown, never, void> {
-    return T.succeed(() => this.value.set(a))
+    return T.succeed(() => {
+      this.value = a
+    })
   }
 
   fold<EC, ED, C, D>(

--- a/packages/system-next/src/Ref/Atomic/operations/getAndSet.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/getAndSet.ts
@@ -3,8 +3,8 @@ import * as T from "./_internal/effect"
 
 export function getAndSet_<A>(self: Atomic<A>, value: A, __trace?: string): T.UIO<A> {
   return T.succeed(() => {
-    const v = self.value.get
-    self.value.set(value)
+    const v = self.value
+    self.value = value
     return v
   }, __trace)
 }

--- a/packages/system-next/src/Ref/Atomic/operations/getAndUpdate.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/getAndUpdate.ts
@@ -7,8 +7,8 @@ export function getAndUpdate_<A>(
   __trace?: string
 ): T.UIO<A> {
   return T.succeed(() => {
-    const v = self.value.get
-    self.value.set(f(v))
+    const v = self.value
+    self.value = f(v)
     return v
   }, __trace)
 }

--- a/packages/system-next/src/Ref/Atomic/operations/getAndUpdateSome.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/getAndUpdateSome.ts
@@ -8,10 +8,10 @@ export function getAndUpdateSome_<A>(
   __trace?: string
 ): T.UIO<A> {
   return T.succeed(() => {
-    const v = self.value.get
+    const v = self.value
     const o = f(v)
     if (o._tag === "Some") {
-      self.value.set(o.value)
+      self.value = o.value
     }
     return v
   }, __trace)

--- a/packages/system-next/src/Ref/Atomic/operations/modify.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/modify.ts
@@ -8,9 +8,9 @@ export function modify_<A, B>(
   __trace?: string
 ): T.UIO<B> {
   return T.succeed(() => {
-    const v = self.value.get
+    const v = self.value
     const o = f(v)
-    self.value.set(o.get(1))
+    self.value = o.get(1)
     return o.get(0)
   }, __trace)
 }

--- a/packages/system-next/src/Ref/Atomic/operations/modifySome.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/modifySome.ts
@@ -10,11 +10,11 @@ export function modifySome_<A, B>(
   __trace?: string
 ): T.UIO<B> {
   return T.succeed(() => {
-    const v = self.value.get
+    const v = self.value
     const o = f(v)
 
     if (o._tag === "Some") {
-      self.value.set(o.value.get(1))
+      self.value = o.value.get(1)
       return o.value.get(0)
     }
 

--- a/packages/system-next/src/Ref/Atomic/operations/unsafeUpdate.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/unsafeUpdate.ts
@@ -1,7 +1,7 @@
 import type { Atomic } from "../Atomic"
 
 export function unsafeUpdate_<A>(self: Atomic<A>, f: (a: A) => A): void {
-  self.value.set(f(self.value.get))
+  self.value = f(self.value)
 }
 
 /**

--- a/packages/system-next/src/Ref/Atomic/operations/update.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/update.ts
@@ -7,7 +7,7 @@ export function update_<A>(
   __trace?: string
 ): T.UIO<void> {
   return T.succeed(() => {
-    self.value.set(f(self.value.get))
+    self.value = f(self.value)
   }, __trace)
 }
 

--- a/packages/system-next/src/Ref/Atomic/operations/updateAndGet.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/updateAndGet.ts
@@ -7,8 +7,8 @@ export function updateAndGet_<A>(
   __trace?: string
 ): T.UIO<A> {
   return T.succeed(() => {
-    self.value.set(f(self.value.get))
-    return self.value.get
+    self.value = f(self.value)
+    return self.value
   }, __trace)
 }
 

--- a/packages/system-next/src/Ref/Atomic/operations/updateSome.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/updateSome.ts
@@ -8,9 +8,9 @@ export function updateSome_<A>(
   __trace?: string
 ): T.UIO<void> {
   return T.succeed(() => {
-    const o = f(self.value.get)
+    const o = f(self.value)
     if (o._tag === "Some") {
-      self.value.set(o.value)
+      self.value = o.value
     }
   }, __trace)
 }

--- a/packages/system-next/src/Ref/Atomic/operations/updateSomeAndGet.ts
+++ b/packages/system-next/src/Ref/Atomic/operations/updateSomeAndGet.ts
@@ -8,13 +8,13 @@ export function updateSomeAndGet_<A>(
   __trace?: string
 ): T.UIO<A> {
   return T.succeed(() => {
-    const o = f(self.value.get)
+    const o = f(self.value)
 
     if (o._tag === "Some") {
-      self.value.set(o.value)
+      self.value = o.value
     }
 
-    return self.value.get
+    return self.value
   }, __trace)
 }
 

--- a/packages/system-next/src/Ref/operations/make.ts
+++ b/packages/system-next/src/Ref/operations/make.ts
@@ -1,4 +1,3 @@
-import { AtomicReference } from "../../Support/AtomicReference"
 import { Atomic } from "../Atomic"
 import type { Ref } from "../definition"
 import * as T from "./_internal/effect"
@@ -11,5 +10,5 @@ export function make<A>(value: A): T.UIO<Ref<A>> {
 }
 
 export function unsafeMake<A>(value: A): Atomic<A> {
-  return new Atomic(new AtomicReference(value))
+  return new Atomic(value)
 }

--- a/packages/system-next/src/Supervisor/operations/fibersIn.ts
+++ b/packages/system-next/src/Supervisor/operations/fibersIn.ts
@@ -16,18 +16,12 @@ export function fibersIn(
       new Supervisor(
         succeed(() => ref.get),
         (environment, effect, parent, fiber) => {
-          let loop = true
-          while (loop) {
-            const set = ref.get
-            loop = !ref.compareAndSet(set, SS.add_(set, fiber))
-          }
+          const set = ref.get
+          ref.set(SS.add_(set, fiber))
         },
         (exit, fiber) => {
-          let loop = true
-          while (loop) {
-            const set = ref.get
-            loop = !ref.compareAndSet(set, SS.remove_(set, fiber))
-          }
+          const set = ref.get
+          ref.set(SS.remove_(set, fiber))
         }
       )
   )

--- a/packages/system-next/src/Transactional/STM/Journal/index.ts
+++ b/packages/system-next/src/Transactional/STM/Journal/index.ts
@@ -75,11 +75,11 @@ export function collectTodos(journal: Journal): Map<TxnId, Todo> {
 
   for (const entry of journal) {
     const tref: Atomic<unknown> = entry[1].use((_) => _.tref as Atomic<unknown>)
-    const todos = tref.todo.get
+    const todos = tref.todo
     for (const todo of todos) {
       allTodos.set(todo[0], todo[1])
     }
-    tref.todo.set(emptyTodoMap)
+    tref.todo = emptyTodoMap
   }
 
   return allTodos
@@ -114,10 +114,10 @@ export function addTodo(txnId: TxnId, journal: Journal, todoEffect: Todo): boole
 
   for (const entry of journal) {
     const tref = entry[1].use((_) => _.tref as Atomic<unknown>)
-    const oldTodo = tref.todo.get
+    const oldTodo = tref.todo
     if (!HM.has_(oldTodo, txnId)) {
       const newTodo = HM.set_(oldTodo, txnId, todoEffect)
-      tref.todo.set(newTodo)
+      tref.todo = newTodo
       added = true
     }
   }

--- a/packages/system-next/src/Transactional/TRef/index.ts
+++ b/packages/system-next/src/Transactional/TRef/index.ts
@@ -3,7 +3,6 @@ import type * as T from "../../Effect"
 import * as E from "../../Either"
 import { identity } from "../../Function"
 import * as O from "../../Option"
-import { AtomicReference } from "../../Support/AtomicReference"
 import { STMEffect } from "../STM/_internal/primitives"
 import * as STM from "../STM/core"
 import { makeEntry } from "../STM/Entry"
@@ -67,10 +66,7 @@ export class Atomic<A> implements XTRef<never, never, A, A> {
   readonly _B!: () => A
   readonly atomic: Atomic<unknown> = this as Atomic<unknown>
 
-  constructor(
-    public versioned: Versioned<A>,
-    readonly todo: AtomicReference<HashMap<TxnId, Todo>>
-  ) {}
+  constructor(public versioned: Versioned<A>, public todo: HashMap<TxnId, Todo>) {}
 
   fold<EC, ED, C, D>(
     _ea: (ea: never) => EC,
@@ -649,7 +645,7 @@ export function makeWith<A>(a: () => A): STM.STM<unknown, never, TRef<A>> {
   return new STMEffect((journal) => {
     const value = a()
     const versioned = new Versioned(value)
-    const todo = new AtomicReference(emptyTodoMap)
+    const todo = emptyTodoMap
     const tref = new Atomic(versioned, todo)
     journal.set(tref, makeEntry(tref, true))
     return tref
@@ -663,7 +659,7 @@ export function make<A>(a: A): STM.STM<unknown, never, TRef<A>> {
   return new STMEffect((journal) => {
     const value = a
     const versioned = new Versioned(value)
-    const todo = new AtomicReference(emptyTodoMap)
+    const todo = emptyTodoMap
     const tref = new Atomic(versioned, todo)
     journal.set(tref, makeEntry(tref, true))
     return tref
@@ -676,7 +672,7 @@ export function make<A>(a: A): STM.STM<unknown, never, TRef<A>> {
 export function unsafeMake<A>(a: A): TRef<A> {
   const value = a
   const versioned = new Versioned(value)
-  const todo = new AtomicReference(emptyTodoMap)
+  const todo = emptyTodoMap
   return new Atomic(versioned, todo)
 }
 


### PR DESCRIPTION
## Summary

Since we don't have to worry about parallelism in a single-threaded runtime, `AtomicReference` and related are used in many places that they don't strictly need to be. This PR removes uses of `AtomicReference` in some hot code paths to avoid the extra function call.