### PR TITLE
fix(supervisor): remove loop in Supervisor.fibersIn

### DIFF
--- a/packages/system-next/src/Supervisor/operations/fibersIn.ts
+++ b/packages/system-next/src/Supervisor/operations/fibersIn.ts
@@ -16,18 +16,12 @@ export function fibersIn(
       new Supervisor(
         succeed(() => ref.get),
         (environment, effect, parent, fiber) => {
-          let loop = true
-          while (loop) {
-            const set = ref.get
-            loop = !ref.compareAndSet(set, SS.add_(set, fiber))
-          }
+          const set = ref.get
+          ref.set(SS.add_(set, fiber))
         },
         (exit, fiber) => {
-          let loop = true
-          while (loop) {
-            const set = ref.get
-            loop = !ref.compareAndSet(set, SS.remove_(set, fiber))
-          }
+          const set = ref.get
+          ref.set(SS.remove_(set, fiber))
         }
       )
   )


### PR DESCRIPTION
This loop is needed in ZIO because `AtomicReference` can be accessed in parallel. But in JS, this isn't an issue