### PR TITLE
feat(eslint-codegen): add pipeable macro

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,10 @@ module.exports = {
   plugins: ["import", "sort-destructure-keys", "simple-import-sort", "codegen"],
   rules: {
     // codegen
-    "codegen/codegen": "error",
+    "codegen/codegen": [
+      "error",
+      { presets: require("./packages/eslint-codegen-effect-ts/dist") }
+    ],
 
     // eslint built-in rules, sorted alphabetically
     "no-constant-condition": "off",

--- a/.vscode/codegen.code-snippets
+++ b/.vscode/codegen.code-snippets
@@ -1,0 +1,10 @@
+{
+    "Effect": {
+      "prefix": "+pipeable",
+      "body": [
+          "// codegen:start { preset: pipeable }",
+          "// codegen:end"
+        ],
+      "description": "Codegen all pipeable functions for this file"
+    }
+}

--- a/packages/eslint-codegen-effect-ts/.gitignore
+++ b/packages/eslint-codegen-effect-ts/.gitignore
@@ -1,0 +1,2 @@
+build/
+dist/

--- a/packages/eslint-codegen-effect-ts/CHANGELOG.md
+++ b/packages/eslint-codegen-effect-ts/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/eslint-codegen-effect-ts/README.md
+++ b/packages/eslint-codegen-effect-ts/README.md
@@ -1,0 +1,21 @@
+### ESLint Codegen Effect-TS
+
+ESLint-Plugin-Codegen preset to allow some codegen stuff
+
+## Install
+
+We recommend the usage of `yarn` and if you hf `yarn workspaces` that handles by default hoisting of dependencies:
+
+```sh
+yarn add @effect-ts/eslint-codegen-effect-ts
+```
+
+You'll then need to update your .eslintrc.js file in order to include the codegen plugin and preset.
+
+```sh
+// codegen
+"codegen/codegen": [
+    "error",
+    { presets: require("./packages/eslint-codegen-effect-ts/dist") }
+],
+```

--- a/packages/eslint-codegen-effect-ts/package.json
+++ b/packages/eslint-codegen-effect-ts/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@effect-ts/eslint-codegen-effect-ts",
+  "version": "0.0.0",
+  "license": "MIT",
+  "repository": "https://github.com/Effect-TS/core.git",
+  "homepage": "https://www.matechs.com",
+  "scripts": {
+    "clean": "yarn ets:rimraf build tsbuildinfo dist",
+    "build-cjs": "yarn ets:tsc -p tsconfig.build.cjs.json",
+    "build-post": "yarn ets:ts-node ../../scripts/pack.ts",
+    "build": "yarn build-cjs && yarn build-post",
+    "lint": "yarn ets:eslint . --ext .ts,.tsx",
+    "autofix": "yarn prettier && yarn lint --fix && yarn prettier",
+    "prettier": "yarn ets:prettier --write \"./{src,test,demo}/**/*.ts\"",
+    "tc": "yarn ets:tsc --noEmit",
+    "circular": "yarn ets:madge --circular --ts-config ./tsconfig.json --extensions ts ./src"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "config": {
+    "side": [],
+    "modules": []
+  }
+}

--- a/packages/eslint-codegen-effect-ts/src/index.ts
+++ b/packages/eslint-codegen-effect-ts/src/index.ts
@@ -1,0 +1,266 @@
+import generate from "@babel/generator"
+import { parse } from "@babel/parser"
+import type { Preset } from "eslint-plugin-codegen"
+import * as fs from "fs"
+import * as ts from "typescript"
+
+/**
+ * A simple static analysis that tries to infer
+ * which generic type declarations are actually used by the signature
+ */
+function interpretReferencedTypeNames(node: ts.TypeNode): string[] {
+  const referencedArgs: string[] = []
+  const stack: ts.TypeNode[] = [node]
+  while (stack.length > 0) {
+    const current = stack.pop()
+    if (!current) return referencedArgs
+
+    if (ts.isTypeReferenceNode(current)) {
+      // A
+      if (current.typeArguments) stack.push(...current.typeArguments)
+      if (ts.isIdentifier(current.typeName)) referencedArgs.push(current.typeName.text)
+    } else if (ts.isUnionTypeNode(current)) {
+      // A | B
+      stack.push(...current.types)
+    } else if (ts.isIntersectionTypeNode(current)) {
+      // A & B
+      stack.push(...current.types)
+    } else if (ts.isFunctionTypeNode(current)) {
+      // (e: E) => A
+      current.parameters.forEach((parameter) => {
+        if (parameter.type) stack.push(parameter.type)
+      })
+      stack.push(current.type)
+    } else if (ts.isIndexedAccessTypeNode(current)) {
+      // A[K]
+      stack.push(current.objectType, current.indexType)
+    } else if (ts.isMappedTypeNode(current)) {
+      // {[P in K]: A}
+      if (current.typeParameter.constraint) stack.push(current.typeParameter.constraint)
+      if (current.type) stack.push(current.type)
+    } else if (ts.isTypeOperatorNode(current)) {
+      // keyof A & company
+      if (current.type) stack.push(current.type)
+    } else if (ts.isTypeLiteralNode(current)) {
+      // {_tag: A}
+      if (current.members)
+        current.members.forEach((member) => {
+          if (ts.isPropertySignature(member) && member.type) {
+            stack.push(member.type)
+          }
+        })
+    } else if (
+      // constant nodes
+      current.kind === ts.SyntaxKind.StringKeyword ||
+      current.kind === ts.SyntaxKind.NumberKeyword ||
+      current.kind === ts.SyntaxKind.NullKeyword ||
+      current.kind === ts.SyntaxKind.BooleanKeyword ||
+      current.kind === ts.SyntaxKind.UnknownKeyword ||
+      current.kind === ts.SyntaxKind.NeverKeyword ||
+      current.kind === ts.SyntaxKind.AnyKeyword
+    ) {
+      // pass
+    } else {
+      // TO BE HANDLED!
+      throw new Error(
+        "Unknown TypeNode " +
+          current.getText() +
+          " while interpreting " +
+          node.getText()
+      )
+    }
+  }
+  return referencedArgs
+}
+
+function normalise(str: string) {
+  try {
+    return generate(
+      parse(str, { sourceType: "module", plugins: ["typescript"] }) as any
+    )
+      .code.replace(/'/g, `"`)
+      .replace(/\/index/g, "")
+  } catch (e) {
+    return str
+  }
+}
+
+function getJSDoc(node: ts.Node): ts.JSDoc | undefined {
+  return "jsDoc" in node ? (node as any).jsDoc[0] : undefined
+}
+
+function updateJSDoc<T extends ts.Node>(node: T, jsDoc: ts.JSDoc) {
+  const comment = ts
+    .createPrinter()
+    .printNode(ts.EmitHint.Unspecified, jsDoc, node.getSourceFile())
+    .trim()
+    .replace(/^\/\*|\*\/$/g, "")
+  return ts.addSyntheticLeadingComment(
+    node,
+    ts.SyntaxKind.MultiLineCommentTrivia,
+    comment,
+    true
+  )
+}
+
+interface DataFirstDeclaration {
+  functionName: string
+  typeParameters: ts.NodeArray<ts.TypeParameterDeclaration>
+  parameters: ts.NodeArray<ts.ParameterDeclaration>
+  type: ts.TypeNode | undefined
+  implemented: boolean
+  jsDoc: ts.JSDoc | undefined
+}
+
+function createPipeableFunctionDeclaration(
+  decl: DataFirstDeclaration
+): ts.FunctionDeclaration {
+  // create the pipeable function name
+  const pipeableName = decl.functionName.substring(0, decl.functionName.length - 1)
+  const pipeableIdentifier = ts.factory.createIdentifier(pipeableName)
+
+  // lookup for used type arguments used by all parameters except the first one
+  const restUsedTypeArgs = decl.parameters
+    .slice(1)
+    .map((parameter) => interpretReferencedTypeNames(parameter.type!))
+    .reduce((curr, a) => curr.concat(a), [])
+
+  const faTypeArgs = decl.typeParameters.filter(
+    (parameter) => restUsedTypeArgs.indexOf(parameter.name.text) === -1
+  )
+  const returnTypeArgs = decl.typeParameters.filter(
+    (parameter) => restUsedTypeArgs.indexOf(parameter.name.text) !== -1
+  )
+
+  // based on if function is implemented or not,
+  // we switch between two different approaches:
+  // export function map(b: B): <A>(a: A) => C
+  // export function map(b: B) { return <A>(a: A): C => }
+  const returnType = decl.type
+    ? ts.factory.createFunctionTypeNode(
+        faTypeArgs,
+        decl.parameters.slice(0, 1),
+        decl.type
+      )
+    : undefined
+
+  const datafirstFunctionCall = ts.factory.createCallExpression(
+    ts.factory.createIdentifier(decl.functionName),
+    [],
+    decl.parameters.map((p, i) =>
+      ts.isIdentifier(p.name)
+        ? p.name
+        : ts.factory.createIdentifier("unknown_parameter_" + i)
+    )
+  )
+
+  const pipeableArrow = ts.factory.createArrowFunction(
+    [],
+    faTypeArgs,
+    decl.parameters.slice(0, 1),
+    decl.type,
+    undefined,
+    datafirstFunctionCall
+  )
+
+  const returnPipeableArrow = ts.factory.createBlock([
+    ts.factory.createReturnStatement(pipeableArrow)
+  ])
+
+  const pipeableFunctionDeclaration = ts.factory.createFunctionDeclaration(
+    [],
+    ts.factory.createModifiersFromModifierFlags(ts.ModifierFlags.Export),
+    undefined,
+    pipeableIdentifier,
+    returnTypeArgs,
+    decl.parameters.slice(1),
+    decl.implemented ? undefined : returnType,
+    decl.implemented ? returnPipeableArrow : undefined
+  )
+
+  const etsDataFirstCommentTag = ts.factory.createJSDocUnknownTag(
+    ts.factory.createIdentifier("ets_data_first"),
+    decl.functionName
+  )
+
+  const baseComment = decl.jsDoc ? decl.jsDoc : ts.factory.createJSDocComment()
+  const baseTags = baseComment.tags || ts.factory.createNodeArray()
+
+  const comment = ts.factory.createJSDocComment(
+    baseComment.comment,
+    baseTags.concat([etsDataFirstCommentTag])
+  )
+
+  return updateJSDoc(pipeableFunctionDeclaration, comment)
+}
+
+function printNode(node: ts.Node, sourceFile: ts.SourceFile): string {
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed
+  })
+  return printer.printNode(ts.EmitHint.Unspecified, node, sourceFile)
+}
+
+export const pipeable: Preset<{
+  exclude?: string
+}> = ({ meta, options }) => {
+  try {
+    // option to exclude some methods
+    const exclude = (options.exclude || "").split(",")
+
+    // checks and reads the file
+    const sourcePath = meta.filename
+    if (!fs.existsSync(sourcePath) || !fs.statSync(sourcePath).isFile()) {
+      throw Error(`Source path is not a file: ${sourcePath}`)
+    }
+    const sourceText = fs.readFileSync(sourcePath).toString()
+
+    // create and parse the AST
+    const sourceFile = ts.createSourceFile(
+      sourcePath,
+      sourceText,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS
+    )
+
+    // collect data-first declarations
+    const dataFirstDeclarations: DataFirstDeclaration[] = sourceFile.statements
+      .filter(ts.isFunctionDeclaration)
+      .filter(
+        (node) =>
+          node.modifiers &&
+          node.modifiers.filter(
+            (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+          ).length > 0
+      )
+      .filter((node) => !!node.name)
+      .filter((node) => node.parameters.length >= 2)
+      .filter((node) => node.name!.getText(sourceFile).endsWith("_"))
+      .map((node) => ({
+        functionName: node.name!.getText(sourceFile),
+        typeParameters: node.typeParameters || ts.factory.createNodeArray(),
+        parameters: node.parameters || ts.factory.createNodeArray(),
+        type: node.type!,
+        implemented: !!node.body,
+        jsDoc: getJSDoc(node)
+      }))
+      .filter((decl) => exclude.indexOf(decl.functionName) === -1)
+
+    // create the actual AST nodes
+    const nodes = dataFirstDeclarations.map(createPipeableFunctionDeclaration)
+    const expectedContent = nodes.map((node) => printNode(node, sourceFile)).join("\n")
+
+    // do not re-emit in a different style, or a loop will occur
+    if (normalise(meta.existingContent) === normalise(expectedContent))
+      return meta.existingContent
+    return expectedContent
+  } catch (e) {
+    return (
+      "/** Got exception: " +
+      ("stack" in (e as any) ? (e as any).stack : "") +
+      JSON.stringify(e) +
+      "*/"
+    )
+  }
+}

--- a/packages/eslint-codegen-effect-ts/tsconfig.build.cjs.json
+++ b/packages/eslint-codegen-effect-ts/tsconfig.build.cjs.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "build/cjs",
+    "target": "ES2018",
+    "module": "CommonJS",
+    "incremental": true,
+    "tsBuildInfoFile": "tsbuildinfo/build.tsbuildinfo",
+    "declarationDir": "build/dts",
+    "removeComments": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/eslint-codegen-effect-ts/tsconfig.build.esm.json
+++ b/packages/eslint-codegen-effect-ts/tsconfig.build.esm.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "build/esm",
+    "target": "ES2018",
+    "module": "ES6",
+    "moduleResolution": "Node",
+    "incremental": true,
+    "tsBuildInfoFile": "tsbuildinfo/esm.tsbuildinfo",
+    "declaration": false,
+    "declarationMap": false,
+    "removeComments": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/eslint-codegen-effect-ts/tsconfig.json
+++ b/packages/eslint-codegen-effect-ts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "target": "ES2018",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "plugins": []
+  },
+  "include": ["src/**/*", "scripts/**/*", "bench/**/*", "test/**/*", "demo/**/*"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -36,7 +36,9 @@
       "@effect-ts/system/*": ["packages/system/build/dts/*"],
       "@effect-ts/system": ["packages/system/build/dts"],
       "@effect-ts/tracing-plugin/*": ["packages/tracing-plugin/build/dts/*"],
-      "@effect-ts/tracing-plugin": ["packages/tracing-plugin/build/dts"]
+      "@effect-ts/tracing-plugin": ["packages/tracing-plugin/build/dts"],
+      "@effect-ts/eslint-codegen-effect-ts/*": ["packages/eslint-codegen-effect-ts/build/dts/*"],
+      "@effect-ts/eslint-codegen-effect-ts": ["packages/eslint-codegen-effect-ts/build/dts"]
     },
     "target": "ES2018"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -512,6 +512,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@effect-ts/eslint-codegen-effect-ts@workspace:packages/eslint-codegen-effect-ts":
+  version: 0.0.0-use.local
+  resolution: "@effect-ts/eslint-codegen-effect-ts@workspace:packages/eslint-codegen-effect-ts"
+  languageName: unknown
+  linkType: soft
+
 "@effect-ts/system-next@workspace:packages/system-next":
   version: 0.0.0-use.local
   resolution: "@effect-ts/system-next@workspace:packages/system-next"


### PR DESCRIPTION
Hoping that this helps the migration project, I wrote this eslint-plugin-codegen preset that auto-writes pipeable signatures based on dataFirst ones.
Once placed on a file by using the snippet +pipeable, it will automagically write all the pipeable signatures for all exported datafirst functions ending with _.
Hope this helps!