### PR TITLE
#1005 - HKT restructuring

### DIFF
--- a/packages/core/src/PreludeV2/FX/index.ts
+++ b/packages/core/src/PreludeV2/FX/index.ts
@@ -1,0 +1,7 @@
+// ets_tracing: off
+
+import type * as HKT from "../HKT"
+
+export interface Fail<F extends HKT.HKT> {
+  readonly fail: <E = never>(e: E) => HKT.Kind<F, any, any, any, unknown, E, never>
+}

--- a/packages/core/src/PreludeV2/HKT/index.ts
+++ b/packages/core/src/PreludeV2/HKT/index.ts
@@ -1,0 +1,77 @@
+import type { InitialVariance, MixVariance } from "./variance"
+
+export declare const URI: unique symbol
+
+export interface Typeclass<F extends HKT> {
+  readonly [URI]?: F
+}
+
+type Param = "X" | "I" | "S" | "R" | "E" | "A"
+type ParamVariance<P extends Param> = {
+  X: "_"
+  I: "_"
+  S: "_"
+  R: "-"
+  E: "+"
+  A: "+"
+}[P]
+
+export interface HKT {
+  readonly X?: unknown
+  readonly I?: unknown
+  readonly S?: unknown
+  readonly R?: unknown
+  readonly E?: unknown
+  readonly A?: unknown
+  readonly type?: unknown
+}
+
+export type Kind<F extends HKT, X, I, S, R, E, A> = F extends { readonly type: unknown }
+  ? (F & {
+      readonly X: X
+      readonly I: I
+      readonly S: S
+      readonly R: R
+      readonly E: E
+      readonly A: A
+    })["type"]
+  : {
+      readonly _F: F
+      readonly X: X
+      readonly I: I
+      readonly S: S
+      readonly _R: (_: R) => void
+      readonly _E: () => E
+      readonly _A: () => A
+    }
+
+export interface ComposeF<F extends HKT, G extends HKT> extends HKT {
+  readonly type: Kind<
+    F,
+    this["X"],
+    this["I"],
+    this["S"],
+    this["R"],
+    this["E"],
+    Kind<G, this["X"], this["I"], this["S"], this["R"], this["E"], this["A"]>
+  >
+}
+
+// Initial type pere parameterized type depending on variance
+export type Initial<P extends Param> = {
+  X: InitialVariance<ParamVariance<"X">>
+  I: InitialVariance<ParamVariance<"I">>
+  S: InitialVariance<ParamVariance<"S">>
+  R: InitialVariance<ParamVariance<"R">>
+  E: InitialVariance<ParamVariance<"E">>
+  A: InitialVariance<ParamVariance<"A">>
+}[P]
+
+export type Mix<P extends Param, X extends [any, ...any[]]> = {
+  X: MixVariance<ParamVariance<"X">, X>
+  I: MixVariance<ParamVariance<"I">, X>
+  S: MixVariance<ParamVariance<"S">, X>
+  R: MixVariance<ParamVariance<"R">, X>
+  E: MixVariance<ParamVariance<"E">, X>
+  A: MixVariance<ParamVariance<"A">, X>
+}[P]

--- a/packages/core/src/PreludeV2/HKT/variance.ts
+++ b/packages/core/src/PreludeV2/HKT/variance.ts
@@ -1,0 +1,33 @@
+import type { UnionToIntersection } from "@effect-ts/system/Utils"
+
+type OrNever<K> = unknown extends K ? never : K
+
+type Variance = "+" | "-" | "_"
+
+export type InitialVariance<V extends Variance> = {
+  "+": never
+  "-": unknown
+  _: any
+}[V]
+
+// composes types according to variance specified in V
+export type MixVariance<V extends Variance, X extends [any, ...any[]]> = V extends "_"
+  ? X[0]
+  : V extends "+"
+  ? X[number]
+  : V extends "-"
+  ? X extends [any]
+    ? X[0]
+    : X extends [any, any]
+    ? X[0] & X[1]
+    : X extends [any, any, any]
+    ? X[0] & X[1] & X[2]
+    : X extends [any, any, any, any]
+    ? X[0] & X[1] & X[2] & X[3]
+    : X extends [any, any, any, any, any]
+    ? X[0] & X[1] & X[2] & X[3] & X[4]
+    : X extends [any, any, any, any, any, any]
+    ? X[0] & X[1] & X[2] & X[3] & X[4] & X[5]
+    : UnionToIntersection<{ [k in keyof X]: OrNever<X[k]> }[keyof X]>
+  : X[0]
+

--- a/packages/core/src/PreludeV2/index.ts
+++ b/packages/core/src/PreludeV2/index.ts
@@ -1,0 +1,97 @@
+import type * as Tp from "@effect-ts/system/Collections/Immutable/Tuple"
+
+import type * as HKT from "./HKT"
+
+export * from "./HKT"
+export * as FX from "./FX"
+
+/**
+ * An associative binary operator that combines two values of types `F<A>`
+ * and `F<B>` to produce an `F<[A, B]>`.
+ */
+export interface AssociativeBoth<F extends HKT.HKT> {
+  both: <X2, I2, S2, R2, E2, B>(
+    fb: HKT.Kind<F, X2, I2, S2, R2, E2, B>
+  ) => <X, I, S, R, E, A>(
+    fa: HKT.Kind<F, X, I, S, R, E, A>
+  ) => HKT.Kind<
+    F,
+    HKT.Mix<"X", [X2, X]>,
+    HKT.Mix<"I", [I2, I]>,
+    HKT.Mix<"S", [S2, S]>,
+    HKT.Mix<"R", [R2, R]>,
+    HKT.Mix<"E", [E2, E]>,
+    Tp.Tuple<[A, B]>
+  >
+}
+
+export interface Any<F extends HKT.HKT> {
+  readonly any: <
+    X = HKT.Initial<"X">,
+    I = HKT.Initial<"I">,
+    S = HKT.Initial<"S">,
+    R = HKT.Initial<"R">,
+    E = HKT.Initial<"E">
+  >() => HKT.Kind<F, X, I, S, R, E, unknown>
+}
+
+/**
+ * Given a function A => B, go from F<A> to F<B>
+ *
+ * ```typescript
+ * declare const user: User
+ * const userName: Option<string> = pipe(O.some(user), O.map(user => user.username))
+ * ```
+ */
+export interface Covariant<F extends HKT.HKT> {
+  readonly map: <A, B>(
+    f: (a: A) => B
+  ) => <
+    X = HKT.Initial<"X">,
+    I = HKT.Initial<"I">,
+    S = HKT.Initial<"S">,
+    R = HKT.Initial<"R">,
+    E = HKT.Initial<"E">
+  >(
+    fa: HKT.Kind<F, X, I, S, R, E, A>
+  ) => HKT.Kind<F, X, I, S, R, E, B>
+}
+
+/**
+ * Describes a type that can be "flattened" in an
+ * associative way.
+ *
+ * ```typescript
+ * declare const user: User
+ * const userName: Option<string> = pipe(
+ *  O.some(user),
+ *  O.map(user => user.email), // Option<Option<string>>
+ *  O.flatten // Option<string>
+ * )
+ * ```
+ */
+export interface AssociativeFlatten<F extends HKT.HKT> {
+  readonly flatten: <X, I, S, R, E, A, X2, I2, S2, R2, E2>(
+    ffa: HKT.Kind<F, X2, I2, S2, R2, E2, HKT.Kind<F, X, I, S, R, E, A>>
+  ) => HKT.Kind<
+    F,
+    HKT.Mix<"X", [X2, X]>,
+    HKT.Mix<"I", [I2, I]>,
+    HKT.Mix<"S", [S2, S]>,
+    HKT.Mix<"R", [R2, R]>,
+    HKT.Mix<"E", [E2, E]>,
+    A
+  >
+}
+
+export type IdentityFlatten<F extends HKT.HKT> = AssociativeFlatten<F> & Any<F>
+
+/**
+ * A binary operator that combines two values of types `F<A>` and `F<B>` to
+ * produce an `F<[A, B]>` with an identity.
+ */
+export interface IdentityBoth<F extends HKT.HKT> extends AssociativeBoth<F>, Any<F> {}
+
+export interface Applicative<F extends HKT.HKT> extends IdentityBoth<F>, Covariant<F> {}
+
+export interface Monad<F extends HKT.HKT> extends IdentityFlatten<F>, Covariant<F> {}


### PR DESCRIPTION
Please note this is just a draft, things are voluntarily kept together to ease refactoring while I am discovering things. 

### 01/22/2022 
Unproven decisions to note:
- Variance is now fixed per parameter and doesn't take into account a fixed type (at least for now)

Example HKT instances
```typescript
export interface AsyncF extends PV2.HKT {
  readonly type: A.Async<this["R"], this["E"], this["A"]>
}

export const Covariant = P.instance<PV2.Covariant<AsyncF>>({
  map: A.map
})

export const Any = P.instance<PV2.Any<AsyncF>>({
  any: () => A.succeed({})
})

export const AssociativeBoth = P.instance<PV2.AssociativeBoth<AsyncF>>({
  both: A.zip
})

...
```