### PR TITLE
Fix naming of `acquireRelease` `Stream` combinators

### DIFF
--- a/.changeset/pretty-fishes-agree.md
+++ b/.changeset/pretty-fishes-agree.md
@@ -1,0 +1,5 @@
+---
+"@effect/core": patch
+---
+
+fix naming of acquireRelease Stream combinators

--- a/packages/core/_src/stream/Stream/operations.ts
+++ b/packages/core/_src/stream/Stream/operations.ts
@@ -1,7 +1,7 @@
 // codegen:start {preset: barrel, include: ./operations/*.ts, prefix: "@effect/core/stream/Stream"}
 export * from "@effect/core/stream/Stream/operations/absolve";
-export * from "@effect/core/stream/Stream/operations/acquireUseRelease";
-export * from "@effect/core/stream/Stream/operations/acquireUseReleaseExit";
+export * from "@effect/core/stream/Stream/operations/acquireRelease";
+export * from "@effect/core/stream/Stream/operations/acquireReleaseExit";
 export * from "@effect/core/stream/Stream/operations/aggregate";
 export * from "@effect/core/stream/Stream/operations/aggregateWithin";
 export * from "@effect/core/stream/Stream/operations/aggregateWithinEither";

--- a/packages/core/_src/stream/Stream/operations/acquireRelease.ts
+++ b/packages/core/_src/stream/Stream/operations/acquireRelease.ts
@@ -2,9 +2,10 @@
  * Creates a stream from a single value that will get cleaned up after the
  * stream is consumed.
  *
- * @tsplus static ets/Stream/Ops acquireUseRelease
+ * @tsplus static ets/Stream/Ops acquireRelease
+ * @tsplus fluent ets/Stream acquireRelease
  */
-export function acquireUseRelease<R, E, A, R2, Z>(
+export function acquireRelease<R, E, A, R2, Z>(
   acquire: LazyArg<Effect<R, E, A>>,
   release: (a: A) => Effect.RIO<R2, Z>,
   __tsplusTrace?: string

--- a/packages/core/_src/stream/Stream/operations/acquireReleaseExit.ts
+++ b/packages/core/_src/stream/Stream/operations/acquireReleaseExit.ts
@@ -2,9 +2,10 @@
  * Creates a stream from a single value that will get cleaned up after the
  * stream is consumed.
  *
- * @tsplus static ets/Stream/Ops acquireUseReleaseExit
+ * @tsplus static ets/Stream/Ops acquireReleaseExit
+ * @tsplus fluent ets/Stream acquireReleaseExit
  */
-export function acquireUseReleaseExit<R, E, A, R2, Z>(
+export function acquireReleaseExit<R, E, A, R2, Z>(
   acquire: LazyArg<Effect<R, E, A>>,
   release: (a: A, exit: Exit<unknown, unknown>) => Effect.RIO<R2, Z>,
   __tsplusTrace?: string

--- a/packages/core/_src/stream/Stream/operations/finalizer.ts
+++ b/packages/core/_src/stream/Stream/operations/finalizer.ts
@@ -8,5 +8,5 @@ export function finalizer<R, Z>(
   finalizer: LazyArg<Effect.RIO<R, Z>>,
   __tsplusTrace?: string
 ): Stream<R, never, void> {
-  return Stream.acquireUseRelease(Effect.unit, finalizer);
+  return Stream.acquireRelease(Effect.unit, finalizer);
 }

--- a/packages/core/_test/stream/Stream/acquireRelease.test.ts
+++ b/packages/core/_test/stream/Stream/acquireRelease.test.ts
@@ -1,12 +1,12 @@
 describe.concurrent("Stream", () => {
-  describe.concurrent("acquireUseRelease", () => {
+  describe.concurrent("acquireRelease", () => {
     it("simple example", async () => {
       const program = Effect.Do()
         .bind("done", () => Ref.make(false))
         .bindValue(
           "stream",
           ({ done }) =>
-            Stream.acquireUseRelease(Effect.succeed(Chunk.range(0, 2)), () => done.set(true)).flatMap((chunk) =>
+            Stream.acquireRelease(Effect.succeed(Chunk.range(0, 2)), () => done.set(true)).flatMap((chunk) =>
               Stream.fromCollection(chunk)
             )
         )
@@ -25,7 +25,7 @@ describe.concurrent("Stream", () => {
         .bindValue(
           "stream",
           ({ done }) =>
-            Stream.acquireUseRelease(Effect.succeed(Chunk.range(0, 3)), () => done.set(true))
+            Stream.acquireRelease(Effect.succeed(Chunk.range(0, 3)), () => done.set(true))
               .flatMap((chunk) => Stream.fromCollection(chunk))
               .take(2)
         )
@@ -43,7 +43,7 @@ describe.concurrent("Stream", () => {
         .bind("acquired", () => Ref.make(false))
         .bindValue("stream", ({ acquired }) =>
           (
-            Stream(1) + Stream.acquireUseRelease(acquired.set(true), () => Effect.unit)
+            Stream(1) + Stream.acquireRelease(acquired.set(true), () => Effect.unit)
           ).take(0))
         .bind("result", ({ stream }) => stream.runDrain())
         .flatMap(({ acquired }) => acquired.get());
@@ -57,7 +57,7 @@ describe.concurrent("Stream", () => {
       const program = Effect.Do()
         .bind("ref", () => Ref.make(false))
         .tap(({ ref }) =>
-          Stream.acquireUseRelease(Effect.unit, () => ref.set(true))
+          Stream.acquireRelease(Effect.unit, () => ref.set(true))
             .flatMap(() => Stream.fromEffect(Effect.dieMessage("boom")))
             .runDrain()
             .exit()
@@ -71,12 +71,12 @@ describe.concurrent("Stream", () => {
 
     it("flatMap associativity doesn't affect acquire release lifetime", async () => {
       const program = Effect.struct({
-        leftAssoc: Stream.acquireUseRelease(Ref.make(true), (ref) => ref.set(false))
+        leftAssoc: Stream.acquireRelease(Ref.make(true), (ref) => ref.set(false))
           .flatMap((ref) => Stream.succeed(ref))
           .flatMap((ref) => Stream.fromEffect(ref.get()))
           .runCollect()
           .map((chunk) => chunk.unsafeHead()),
-        rightAssoc: Stream.acquireUseRelease(Ref.make(true), (ref) => ref.set(false))
+        rightAssoc: Stream.acquireRelease(Ref.make(true), (ref) => ref.set(false))
           .flatMap((ref) => Stream.succeed(ref).flatMap((ref) => Stream.fromEffect(ref.get())))
           .runCollect()
           .map((chunk) => chunk.unsafeHead())
@@ -89,7 +89,7 @@ describe.concurrent("Stream", () => {
     });
 
     it("propagates errors", async () => {
-      const program = Stream.acquireUseRelease(Effect.unit, () => Effect.dieMessage("die")).runCollect();
+      const program = Stream.acquireRelease(Effect.unit, () => Effect.dieMessage("die")).runCollect();
 
       const result = await program.unsafeRunPromiseExit();
 

--- a/packages/core/_test/stream/Stream/catch.test.ts
+++ b/packages/core/_test/stream/Stream/catch.test.ts
@@ -80,7 +80,7 @@ describe.concurrent("Stream", () => {
     it("propagates the right exit value to the failing stream (ZIO issue #3609)", async () => {
       const program = Ref.make<Exit<unknown, unknown>>(Exit.unit)
         .tap((ref) =>
-          Stream.acquireUseReleaseExit(Effect.unit, (_, exit) => ref.set(exit))
+          Stream.acquireReleaseExit(Effect.unit, (_, exit) => ref.set(exit))
             .flatMap(() => Stream.fail("boom"))
             .either()
             .runDrain()

--- a/packages/core/_test/stream/Stream/finalizers.test.ts
+++ b/packages/core/_test/stream/Stream/finalizers.test.ts
@@ -5,7 +5,7 @@ describe.concurrent("Stream", () => {
       const program = Effect.Do()
         .bind("log", () => Ref.make<List<string>>(List.empty()))
         .tap(({ log }) =>
-          Stream.acquireUseRelease(log.update(event("acquire")), () => log.update(event("release")))
+          Stream.acquireRelease(log.update(event("acquire")), () => log.update(event("release")))
             .flatMap(() => Stream.fromEffect(log.update(event("use"))))
             .ensuring(log.update(event("ensuring")))
             .runDrain()
@@ -34,7 +34,7 @@ describe.concurrent("Stream", () => {
           ({ log }) => (label: string) => log.update((list) => list.prepend(label))
         )
         .tap(({ entry }) =>
-          Stream.acquireUseRelease(entry("Acquire"), () => entry("Release"))
+          Stream.acquireRelease(entry("Acquire"), () => entry("Release"))
             .flatMap(() => Stream.finalizer(entry("Use")))
             .ensuring(entry("Ensuring"))
             .runDrain()

--- a/packages/core/_test/stream/Stream/flatMap.test.ts
+++ b/packages/core/_test/stream/Stream/flatMap.test.ts
@@ -65,9 +65,9 @@ describe.concurrent("Stream", () => {
         .bind("latch", () => Deferred.make<never, void>())
         .bind("fiber", ({ latch, push }) =>
           Stream(
-            Stream.acquireUseRelease(push(1), () => push(1)),
+            Stream.acquireRelease(push(1), () => push(1)),
             Stream.fromEffect(push(2)),
-            Stream.acquireUseRelease(push(3), () => push(3)) >
+            Stream.acquireRelease(push(3), () => push(3)) >
               Stream.fromEffect(latch.succeed(undefined) > Effect.never)
           )
             .flatMap(identity)
@@ -92,12 +92,12 @@ describe.concurrent("Stream", () => {
         .bindValue(
           "stream",
           ({ push }) =>
-            Stream.acquireUseRelease(push("open1"), () => push("close1")).flatMap(() =>
+            Stream.acquireRelease(push("open1"), () => push("close1")).flatMap(() =>
               Stream.fromChunks(Chunk(undefined), Chunk(undefined))
                 .tap(() => push("use2"))
                 .ensuring(push("close2"))
                 .flatMap(() =>
-                  Stream.acquireUseRelease(push("open3"), () => push("close3")).flatMap(
+                  Stream.acquireRelease(push("open3"), () => push("close3")).flatMap(
                     () =>
                       Stream.fromChunks(Chunk(undefined), Chunk(undefined))
                         .tap(() => push("use4"))
@@ -142,7 +142,7 @@ describe.concurrent("Stream", () => {
         .bindValue("stream", ({ push }) =>
           Stream.fromChunks(Chunk(1), Chunk(2))
             .tap(() => push("use2"))
-            .flatMap(() => Stream.acquireUseRelease(push("open3"), () => push("close3"))))
+            .flatMap(() => Stream.acquireRelease(push("open3"), () => push("close3"))))
         .tap(({ stream }) => stream.runDrain())
         .flatMap(({ effects }) => effects.get());
 
@@ -164,7 +164,7 @@ describe.concurrent("Stream", () => {
       const program = Effect.Do()
         .bind("ref", () => Ref.make(constFalse))
         .bindValue("inner", ({ ref }) =>
-          Stream.acquireUseReleaseExit(Effect.unit, (_, exit) =>
+          Stream.acquireReleaseExit(Effect.unit, (_, exit) =>
             exit.fold(
               () => ref.set(true),
               () => Effect.unit

--- a/packages/core/_test/stream/Stream/flatMapPar.test.ts
+++ b/packages/core/_test/stream/Stream/flatMapPar.test.ts
@@ -146,9 +146,9 @@ describe.concurrent("Stream", () => {
           "push",
           ({ effects }) => (label: string) => effects.update((list) => list.prepend(label))
         )
-        .bindValue("inner", ({ push }) => Stream.acquireUseRelease(push("InnerAcquire"), () => push("InnerRelease")))
+        .bindValue("inner", ({ push }) => Stream.acquireRelease(push("InnerAcquire"), () => push("InnerRelease")))
         .tap(({ inner, push }) =>
-          Stream.acquireUseRelease(push("OuterAcquire").as(inner), () => push("OuterRelease"))
+          Stream.acquireRelease(push("OuterAcquire").as(inner), () => push("OuterRelease"))
             .flatMapPar(2, identity)
             .runDrain()
         )

--- a/packages/core/_test/stream/Stream/flatMapParSwitch.test.ts
+++ b/packages/core/_test/stream/Stream/flatMapParSwitch.test.ts
@@ -8,7 +8,7 @@ describe.concurrent("Stream", () => {
           Stream(1, 2, 3, 4)
             .flatMapParSwitch(1, (i) =>
               i > 3
-                ? Stream.acquireUseRelease(Effect.unit, () => lastExecuted.set(true)).flatMap(() => Stream.empty)
+                ? Stream.acquireRelease(Effect.unit, () => lastExecuted.set(true)).flatMap(() => Stream.empty)
                 : Stream.scoped(semaphore.withPermitScoped).flatMap(
                   () => Stream.never
                 ))
@@ -29,7 +29,7 @@ describe.concurrent("Stream", () => {
           Stream.range(1, 13)
             .flatMapParSwitch(4, (i) =>
               i > 8
-                ? Stream.acquireUseRelease(Effect.unit, () => lastExecuted.update((n) => n + 1)).flatMap(() =>
+                ? Stream.acquireRelease(Effect.unit, () => lastExecuted.update((n) => n + 1)).flatMap(() =>
                   Stream.empty
                 )
                 : Stream.scoped(semaphore.withPermitScoped).flatMap(
@@ -175,9 +175,9 @@ describe.concurrent("Stream", () => {
           "push",
           ({ effects }) => (label: string) => effects.update((list) => list.prepend(label))
         )
-        .bindValue("inner", ({ push }) => Stream.acquireUseRelease(push("InnerAcquire"), () => push("InnerRelease")))
+        .bindValue("inner", ({ push }) => Stream.acquireRelease(push("InnerAcquire"), () => push("InnerRelease")))
         .tap(({ inner, push }) =>
-          Stream.acquireUseRelease(push("OuterAcquire").as(inner), () => push("OuterRelease"))
+          Stream.acquireRelease(push("OuterAcquire").as(inner), () => push("OuterRelease"))
             .flatMapParSwitch(2, identity)
             .runDrain()
         )


### PR DESCRIPTION
This PR fixes the naming of the `acquireRelease*` combinators in the `Stream` modules, and also adds a fluent `tsplus` annotation to them.