### PR TITLE
Add custom lookup on map keys

### DIFF
--- a/packages/core/src/Collections/Immutable/Map/index.ts
+++ b/packages/core/src/Collections/Immutable/Map/index.ts
@@ -3,3 +3,4 @@
 import "../../../Operator/index.js"
 
 export * from "@effect-ts/system/Collections/Immutable/Map"
+export * from "./instances.js"

--- a/packages/core/src/Collections/Immutable/Map/instances.ts
+++ b/packages/core/src/Collections/Immutable/Map/instances.ts
@@ -1,0 +1,47 @@
+// ets_tracing: off
+
+/* adapted from https://github.com/gcanti/fp-ts */
+
+import * as M from "@effect-ts/system/Collections/Immutable/Map"
+import type { Equal } from "@effect-ts/system/Equal"
+import { makeEqual } from "@effect-ts/system/Equal"
+
+import type { Associative } from "../../../Associative"
+import type { Identity } from "../../../Identity/index.js"
+import { makeIdentity } from "../../../Identity/index.js"
+import * as Op from "../../../Option"
+
+export function getIdentityEq<K, A>(
+  eq: Equal<K>,
+  associative: Associative<A>
+): Identity<M.Map<K, A>> {
+  return makeIdentity<M.Map<K, A>>(M.empty, (mx, my) => {
+    if (M.isEmpty(mx)) return my
+
+    if (M.isEmpty(my)) return mx
+
+    const lookup = M.lookupWithKeyEq(eq)
+    const r = new Map(mx)
+    const entries = my.entries()
+
+    let e: M.Next<readonly [K, A]>
+
+    while (!(e = entries.next()).done) {
+      const [k, a] = e.value
+      const match = lookup(k)(mx)
+
+      if (Op.isSome(match)) {
+        r.set(match.value.get(0), associative.combine(match.value.get(1), a))
+      } else {
+        r.set(k, a)
+      }
+    }
+    return r
+  })
+}
+
+const eqInstance = <A>() => makeEqual<A>((x, y) => x == y)
+
+export function getIdentity<K, A>(associative: Associative<A>): Identity<M.Map<K, A>> {
+  return getIdentityEq(eqInstance<K>(), associative)
+}

--- a/packages/core/test/map.test.ts
+++ b/packages/core/test/map.test.ts
@@ -1,0 +1,49 @@
+import * as AR from "../src/Collections/Immutable/Array/index.js"
+import * as MAP from "../src/Collections/Immutable/Map/index.js"
+
+describe(`Map`, () => {
+  describe(`getIdentity`, () => {
+    test(`A Map empty returns B map untouched`, () => {
+      const A = MAP.empty
+      const B = MAP.make([["B_prop", ["B_prop_value"]]])
+
+      const identity = MAP.getIdentity(AR.getIdentity<string>())
+
+      expect(identity.combine(A, B)).toBe(B)
+    })
+
+    test(`B Map empty returns A map untouched`, () => {
+      const A = MAP.make([["A_prop", ["A_prop_value"]]])
+      const B = MAP.empty
+
+      const identity = MAP.getIdentity(AR.getIdentity<string>())
+
+      expect(identity.combine(A, B)).toBe(A)
+    })
+
+    test(`Adds prop from A & B maps`, () => {
+      const A = MAP.make([["A_prop", ["A_prop_value"]]])
+      const B = MAP.make([["B_prop", ["B_prop_value"]]])
+
+      const identity = MAP.getIdentity(AR.getIdentity<string>())
+
+      expect(identity.combine(A, B)).toStrictEqual(
+        MAP.make([
+          ["A_prop", ["A_prop_value"]],
+          ["B_prop", ["B_prop_value"]]
+        ])
+      )
+    })
+
+    test(`Merges shared prop values`, () => {
+      const A = MAP.make([["shared_prop", ["value_from_map_A"]]])
+      const B = MAP.make([["shared_prop", ["value_from_map_B"]]])
+
+      const identity = MAP.getIdentity(AR.getIdentity<string>())
+
+      expect(identity.combine(A, B)).toStrictEqual(
+        MAP.make([["shared_prop", ["value_from_map_A", "value_from_map_B"]]])
+      )
+    })
+  })
+})

--- a/packages/system/test/collections/map.test.ts
+++ b/packages/system/test/collections/map.test.ts
@@ -1,0 +1,46 @@
+import * as M from "../../src/Collections/Immutable/Map"
+import * as EQ from "../../src/Equal"
+import * as OP from "../../src/Option"
+
+describe(`Map`, () => {
+  describe(`lookupEq`, () => {
+    test(`No match returns None`, () => {
+      const mapWithNoMatchForLookedUpKey = M.make([["A", "key_A_value"]])
+      const result = M.lookupEq_(EQ.string, mapWithNoMatchForLookedUpKey, "B")
+
+      expect(result).toEqual(OP.none)
+    })
+
+    test(`Match returns value`, () => {
+      const lookedUpKeyName = "A"
+      const lookedUpKeyValue = "A_value"
+      const mapWithAMatchForLookedUpKey = M.make([[lookedUpKeyName, lookedUpKeyValue]])
+
+      const result = M.lookupEq_(
+        EQ.string,
+        mapWithAMatchForLookedUpKey,
+        lookedUpKeyName
+      )
+
+      expect(result).toEqual(OP.some(lookedUpKeyValue))
+    })
+  })
+
+  describe(`removeEq`, () => {
+    test(`No key matching does nothing`, () => {
+      const mapWithNoMatchForDeletedKey = M.make([["A", "key_A_value"]])
+
+      const result = M.removeEq_(EQ.string, mapWithNoMatchForDeletedKey, "B")
+
+      expect(mapWithNoMatchForDeletedKey).toEqual(result)
+    })
+
+    test(`Matching key returns new map without deleted key`, () => {
+      const mapWithAMatchForDeletedKey = M.make([["A", "key_A_value"]])
+
+      const result = M.removeEq_(EQ.string, mapWithAMatchForDeletedKey, "A")
+
+      expect(result).toEqual(M.empty)
+    })
+  })
+})


### PR DESCRIPTION
Adds the ability to pass a custom matcher (eq) for map keys.

Added functions
- lookupEq (system)
- removeEq (system)
- getIdentityEq (core)
- getIdentity (core)

I'm afraid this might make the API for map more confusing than anything (also, @mikearnaldi made a very good point about using `HashMap` for this use case) so don't hesitate to reject the PR ;).
