### PR TITLE
Add missing 'self' referenced in the description

### DIFF
--- a/packages/system/src/Either/core.ts
+++ b/packages/system/src/Either/core.ts
@@ -285,22 +285,22 @@ export function exists_<E, A>(ma: Either<E, A>, predicate: Predicate<A>): boolea
 }
 
 /**
- * Apply `Either[E, A] => B` in case self is right returning `Either[E, B]`
+ * Apply `Either[E, A] => B` in case `self` is `Right` returning `Either[E, B]`
  */
 export function extend_<E, A, B>(
-  wa: Either<E, A>,
+  self: Either<E, A>,
   f: (wa: Either<E, A>) => B
 ): Either<E, B> {
-  return isLeft(wa) ? wa : right(f(wa))
+  return isLeft(self) ? self : right(f(self))
 }
 
 /**
- * Apply `Either[E, A] => B` in case self is right returning `Either[E, B]`
+ * Apply `Either[E, A] => B` in case `self` is `Right` returning `Either[E, B]`
  *
  * @ets_data_first extend_
  */
 export function extend<E, A, B>(f: (fa: Either<E, A>) => B) {
-  return (ma: Either<E, A>): Either<E, B> => extend_(ma, f)
+  return (self: Either<E, A>): Either<E, B> => extend_(self, f)
 }
 
 /**


### PR DESCRIPTION
### I'm not quite sure if this change is correct, please review it more carefully.

I've noticed that `self` is used across your project as well as `ma`, `wa` shorthands. As far self was used in the description I decided to put it in the function definition. It could be done in opposite way, that is adjust description to the name `wa`.