### PR TITLE
chore: use Clock.currentTime in logging vs. Date.now()

### DIFF
--- a/packages/core/_src/io/Effect/operations/logging.ts
+++ b/packages/core/_src/io/Effect/operations/logging.ts
@@ -263,13 +263,14 @@ export function logTraceCauseMessage<E>(
 export function logSpan(label: string) {
   return <R, E, A>(effect: Effect<R, E, A>): Effect<R, E, A> =>
     FiberRef.currentLogSpan.get.flatMap((stack) =>
-      Effect.suspendSucceed(() => {
-        const now = Date.now()
-        const logSpan = LogSpan(label, now)
-        return effect.apply(
-          FiberRef.currentLogSpan.locally(stack.prepend(logSpan))
-        )
-      })
+      Clock.currentTime.flatMap((now) =>
+        Effect.suspendSucceed(() => {
+          const logSpan = LogSpan(label, now)
+          return effect.apply(
+            FiberRef.currentLogSpan.locally(stack.prepend(logSpan))
+          )
+        })
+      )
     )
 }
 


### PR DESCRIPTION
Nothing significant, just using the built in clock service vs. `Date.now()` in `logSpan`