### PR TITLE
Add Effect.existsPar

### DIFF
--- a/packages/core/_src/io/Effect/operations/exists.ts
+++ b/packages/core/_src/io/Effect/operations/exists.ts
@@ -1,6 +1,6 @@
 /**
  * Determines whether any element of the `Collection<A>` satisfies the effectual
- * predicate `f`.
+ * predicate `f`, working sequentially.
  *
  * @tsplus static effect/core/io/Effect.Ops exists
  */

--- a/packages/core/_src/io/Effect/operations/existsPar.ts
+++ b/packages/core/_src/io/Effect/operations/existsPar.ts
@@ -1,0 +1,19 @@
+const _found = Symbol("found")
+
+/**
+ * Determines whether any element of the `Collection<A>` satisfies the effectual
+ * predicate `f`, working in parallel. Interrupts all effects on any failure or
+ * finding an element that satisfies the predicate.
+ *
+ * @tsplus static effect/core/io/Effect.Ops existsPar
+ */
+export function existsPar<R, E, A>(
+  as: Collection<A>,
+  f: (a: A) => Effect<R, E, boolean>
+): Effect<R, E, boolean> {
+  return Effect.forEachPar(as, (a) => Effect.ifEffect(f(a), Effect.fail(_found), Effect.unit))
+    .foldEffect(
+      (e) => e === _found ? Effect.succeed(true) : Effect.fail(e),
+      () => Effect.succeed(false)
+    )
+}


### PR DESCRIPTION
Parrallel version of `exists`.

`existsPar` determines whether any element of the `Collection<A>` satisfies the effectual
predicate `f`, working in parallel. Interrupts all effects on any failure or
finding an element that satisfies the predicate.